### PR TITLE
fix: Double Knuth audit — 51 fixes across security, correctness, and deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -91,7 +94,59 @@ jobs:
             ${{ runner.os }}-cargo-clippy-
 
       - name: Run clippy
-        run: cargo clippy --workspace --exclude arvak-python -- -W clippy::all
+        run: >
+          cargo clippy
+          --workspace
+          --exclude arvak-python
+          --all-targets
+          -- -D warnings -D clippy::all
+          -W clippy::pedantic
+          -A clippy::missing-errors-doc
+          -A clippy::missing-panics-doc
+          -A clippy::module-name-repetitions
+          -A clippy::must-use-candidate
+          -A clippy::return-self-not-must-use
+          -A clippy::similar-names
+          -A clippy::many-single-char-names
+          -A clippy::cast-possible-truncation
+          -A clippy::cast-precision-loss
+          -A clippy::cast-sign-loss
+          -A clippy::cast-possible-wrap
+          -A clippy::doc-markdown
+          -A clippy::wildcard-imports
+          -A clippy::items-after-statements
+          -A clippy::implicit-hasher
+          -A clippy::unnecessary-debug-formatting
+          -A clippy::struct-excessive-bools
+          -A clippy::uninlined-format-args
+          -A clippy::trivially-copy-pass-by-ref
+          -A clippy::float-cmp
+          -A clippy::unreadable-literal
+          -A clippy::unused-self
+          -A clippy::match-same-arms
+          -A clippy::needless-pass-by-value
+          -A clippy::format-push-string
+          -A clippy::missing-fields-in-debug
+          -A clippy::too-many-lines
+          -A clippy::no-effect-underscore-binding
+          -A clippy::unnecessary-wraps
+          -A clippy::only-used-in-recursion
+          -A clippy::self-only-used-in-recursion
+          -A clippy::needless-continue
+          -A clippy::redundant-else
+          -A clippy::option-if-let-else
+          -A clippy::if-not-else
+          -A clippy::manual-let-else
+          -A clippy::single-match-else
+          -A clippy::used-underscore-binding
+          -A clippy::default-trait-access
+          -A clippy::non-std-lazy-statics
+          -A clippy::unnecessary-sort-by
+          -A clippy::type-complexity
+          -A clippy::too-many-arguments
+          -A clippy::unused-async
+          -A clippy::ref-option
+          -A clippy::semicolon-if-nothing-returned
 
   build:
     name: Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# Arvak Project — Claude Code Guidelines
+
+## Build & Test
+
+```bash
+# Standard check (excludes arvak-python which requires a Python venv)
+cargo check --workspace --exclude arvak-python
+cargo test --workspace --exclude arvak-python
+cargo fmt --all
+
+# Strict clippy (matches nightly CI — see .github/workflows/nightly.yml lines 247-299)
+cargo clippy --workspace --exclude arvak-python --all-targets -- \
+  -D warnings -D clippy::all -W clippy::pedantic \
+  -A clippy::missing-errors-doc -A clippy::missing-panics-doc \
+  -A clippy::module-name-repetitions -A clippy::must-use-candidate \
+  -A clippy::return-self-not-must-use -A clippy::similar-names \
+  -A clippy::many-single-char-names -A clippy::cast-possible-truncation \
+  -A clippy::cast-precision-loss -A clippy::cast-sign-loss \
+  -A clippy::cast-possible-wrap -A clippy::doc-markdown \
+  -A clippy::wildcard-imports -A clippy::items-after-statements \
+  -A clippy::implicit-hasher -A clippy::unnecessary-debug-formatting \
+  -A clippy::struct-excessive-bools -A clippy::uninlined-format-args \
+  -A clippy::trivially-copy-pass-by-ref -A clippy::float-cmp \
+  -A clippy::unreadable-literal -A clippy::unused-self \
+  -A clippy::match-same-arms -A clippy::needless-pass-by-value \
+  -A clippy::format-push-string -A clippy::missing-fields-in-debug \
+  -A clippy::too-many-lines -A clippy::no-effect-underscore-binding \
+  -A clippy::unnecessary-wraps -A clippy::only-used-in-recursion \
+  -A clippy::self-only-used-in-recursion -A clippy::needless-continue \
+  -A clippy::redundant-else -A clippy::option-if-let-else \
+  -A clippy::if-not-else -A clippy::manual-let-else \
+  -A clippy::single-match-else -A clippy::used-underscore-binding \
+  -A clippy::default-trait-access -A clippy::non-std-lazy-statics \
+  -A clippy::unnecessary-sort-by -A clippy::type-complexity \
+  -A clippy::too-many-arguments -A clippy::unused-async \
+  -A clippy::ref-option -A clippy::semicolon-if-nothing-returned
+```
+
+Always run `cargo fmt --all` after editing Rust files. The nightly CI denies warnings with pedantic clippy.
+
+## Coding Patterns (from nightly CI failures)
+
+### Checked casts: use `try_from` instead of `as` with assertions
+```rust
+// BAD — triggers clippy::checked_conversions
+debug_assert!(id <= u32::MAX as usize);
+let val = id as u32;
+
+// GOOD
+let val = u32::try_from(id).expect("overflow: exceeds u32::MAX");
+```
+
+### Method references over redundant closures
+```rust
+// BAD — triggers clippy::redundant_closure
+.unwrap_or_else(|e| e.into_inner())
+
+// GOOD
+.unwrap_or_else(std::sync::PoisonError::into_inner)
+```
+
+### `is_ok_and` over `map().unwrap_or(false)` on Result
+```rust
+// BAD — triggers clippy::map_unwrap_or
+result.map(|a| a.is_available).unwrap_or(false)
+
+// GOOD
+result.is_ok_and(|a| a.is_available)
+```
+
+### Iterate references directly
+```rust
+// BAD — triggers clippy::explicit_iter_loop
+for item in self.items.iter() { }
+
+// GOOD
+for item in &self.items { }
+```
+
+### Suppress `unnecessary_literal_bound` for trait impls returning `&'static str`
+```rust
+// When a Backend trait requires `fn name(&self) -> &str` and you return a literal:
+#[allow(clippy::unnecessary_literal_bound)]
+fn name(&self) -> &str {
+    "my-backend"
+}
+```
+
+## Rules (from Double Knuth audit)
+
+### Security
+- **Never use `innerHTML` with unsanitized data.** Always pass server-returned values through `escapeHtml()` or use `textContent`. The dashboard's `escapeHtml()` helper exists in `static/app.js`.
+- **Never derive `Debug` on structs containing tokens or secrets.** Implement `Debug` manually with redacted fields (e.g., `field("token", &"[REDACTED]")`).
+- **Create credential files with restrictive permissions atomically.** Use `OpenOptions::new().mode(0o600)` on Unix — never write then chmod (TOCTOU race).
+- **CORS must be configurable**, not hardcoded to `Any`. Read from env var with graceful fallback — never `.expect()` on user-provided env vars.
+- **HTTP clients must set timeouts.** Always add `.timeout()` and `.connect_timeout()` to reqwest client builders.
+
+### Async & Concurrency
+- **Use `tokio::sync::Mutex`/`RwLock` in async contexts**, not `std::sync::Mutex`. Holding a std Mutex across `.await` can deadlock.
+- **Use `tokio::task::spawn_blocking()` for CPU-bound work** (e.g., simulation, heavy computation) inside async functions.
+- **Caches need eviction.** Job caches, result caches, and in-memory storage must have a size limit (e.g., `MAX_CACHED_JOBS = 10_000`) with eviction of terminal-state entries.
+- **Backend info caches need a TTL** (e.g., 5 minutes). Never cache indefinitely — backends go offline.
+
+### Arithmetic & Overflow
+- **Use `checked_add` for ID counters**, not `+=`. Wrapping on overflow silently produces duplicate IDs.
+- **Use `try_from` for narrowing casts**, not `as`. This includes `u64 as u32`, config values, and shot counts. Provide a sensible fallback: `u32::try_from(v).unwrap_or(default)`.
+- **Guard division** — check for zero denominators before dividing, especially for computed values like `total_shots`, `qubits_per_zone`.
+- **Use `rem_euclid` for angle normalization**, not while loops. `while` loops on floats can hang for extreme values.
+
+### API Consistency
+- **`FromIterator`, `from_pairs`, and `insert` must have consistent semantics.** If `insert` accumulates, `FromIterator` and `from_pairs` must also accumulate.
+- **Never silently skip unsupported operations.** Return an error instead — silently skipping gates/params produces incorrect results with no diagnostic.
+- **`validate()` must check both qubit count and gate set.** Gate set validation catches unsupported gates at submission time rather than producing cryptic backend errors.
+- **Batch operations must check resource limits per item**, not once before the loop. Increment counters after each successful item.
+- **Gate set must cover all arities.** `GateSet::contains()` checks single-qubit, two-qubit, and three-qubit lists.
+
+### Dependencies
+- **Use workspace dependencies consistently.** Never use direct `path = "..."` when a `[workspace.dependencies]` entry exists.
+- **Use `serde_yml`**, not `serde_yaml` (deprecated, RUSTSEC-2024-0320).
+- **Use `tracing`**, not `log`. All crates use `tracing` — the `log` crate's macros won't appear in tracing subscriber output.
+
+### DAG Operations
+- **`dag.apply()` appends at wire ends, not at specific positions.** Passes that need positional insertion (routing SWAPs, noise channels) must document this limitation. A `CircuitDag::insert_before(node, inst)` API is needed for correct operation ordering.
+- **`substitute_node` invalidates collected `NodeIndex` values** via petgraph's swap-remove. Process nodes in reverse order or re-discover after each substitution.
+
+## Project Structure
+
+- `crates/` — Core crates (arvak-ir, arvak-hal, arvak-compile, arvak-grpc, arvak-cli, etc.)
+- `adapters/` — Backend adapters (arvak-adapter-sim, arvak-adapter-ibm, arvak-adapter-iqm, arvak-adapter-qdmi)
+- `crates/arvak-python` — Python bindings (PyO3/maturin, needs Python venv — always exclude from workspace commands)
+
+## Deployment
+
+Use `/deploydemo` skill to deploy to arvak.io (Docker build + scp + ssh restart).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-cudaq"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-ibm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-iqm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-qdmi"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-sim"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-auto"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-ir",
  "petgraph",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-bench"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-compile",
  "arvak-ir",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-ibm",
@@ -250,7 +250,7 @@ dependencies = [
  "mimalloc",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "tempfile",
  "tokio",
  "tracing",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-compile"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-ir",
  "num-complex",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-dashboard"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-sim",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-demos"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-compile",
  "arvak-hal",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-eval"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-compile",
  "arvak-hal",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-grpc"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-sim",
@@ -368,7 +368,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-hal"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-ir",
  "async-trait",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-ir"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "num-complex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-python"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-adapter-sim",
  "arvak-compile",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-qasm3"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-ir",
  "logos",
@@ -443,18 +443,17 @@ dependencies = [
 
 [[package]]
 name = "arvak-qdmi"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
- "env_logger",
  "libloading",
- "log",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "arvak-sched"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -476,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-types"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "arvak-ir",
  "proptest",
@@ -1170,29 +1169,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -1984,30 +1960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jiff"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2026,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -2144,7 +2106,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumi-hybrid"
-version = "1.0.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -3374,16 +3336,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -4168,12 +4132,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 
 # Graph algorithms
 petgraph = "0.7"
@@ -85,6 +85,9 @@ libloading = "0.8"
 
 # Allocator
 mimalloc = { version = "0.1", default-features = false }
+
+# Random
+rand = "0.8"
 
 # Testing
 proptest = "1.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY crates/arvak-auto/Cargo.toml crates/arvak-auto/Cargo.toml
 COPY crates/arvak-dashboard/Cargo.toml crates/arvak-dashboard/Cargo.toml
 COPY crates/arvak-cli/Cargo.toml crates/arvak-cli/Cargo.toml
 COPY crates/arvak-grpc/Cargo.toml crates/arvak-grpc/Cargo.toml
+COPY crates/arvak-qdmi/Cargo.toml crates/arvak-qdmi/Cargo.toml
 COPY adapters/arvak-adapter-ibm/Cargo.toml adapters/arvak-adapter-ibm/Cargo.toml
 COPY adapters/arvak-adapter-iqm/Cargo.toml adapters/arvak-adapter-iqm/Cargo.toml
 COPY adapters/arvak-adapter-qdmi/Cargo.toml adapters/arvak-adapter-qdmi/Cargo.toml
@@ -70,6 +71,7 @@ RUN mkdir -p crates/arvak-ir/src && echo "" > crates/arvak-ir/src/lib.rs \
         && echo "fn main() {}" > crates/arvak-grpc/src/bin/arvak-grpc-server.rs \
     && mkdir -p crates/arvak-grpc/proto \
         && touch crates/arvak-grpc/proto/arvak.proto \
+    && mkdir -p crates/arvak-qdmi/src && echo "" > crates/arvak-qdmi/src/lib.rs \
     && mkdir -p adapters/arvak-adapter-ibm/src && echo "" > adapters/arvak-adapter-ibm/src/lib.rs \
     && mkdir -p adapters/arvak-adapter-iqm/src && echo "" > adapters/arvak-adapter-iqm/src/lib.rs \
     && mkdir -p adapters/arvak-adapter-qdmi/src && echo "" > adapters/arvak-adapter-qdmi/src/lib.rs \
@@ -85,6 +87,9 @@ RUN mkdir -p crates/arvak-ir/src && echo "" > crates/arvak-ir/src/lib.rs \
         && echo "fn main() {}" > demos/bin/demo_multi.rs \
         && echo "fn main() {}" > demos/bin/demo_all.rs \
         && echo "fn main() {}" > demos/bin/demo_qi_nutshell.rs \
+        && echo "fn main() {}" > demos/bin/demo_speed_vqe.rs \
+        && echo "fn main() {}" > demos/bin/demo_speed_qml.rs \
+        && echo "fn main() {}" > demos/bin/demo_speed_qaoa.rs \
     && mkdir -p demos/lumi-hybrid/src \
         && echo "fn main() {}" > demos/lumi-hybrid/src/main.rs \
         && echo "fn main() {}" > demos/lumi-hybrid/src/quantum_worker.rs \

--- a/adapters/arvak-adapter-ibm/src/api.rs
+++ b/adapters/arvak-adapter-ibm/src/api.rs
@@ -51,7 +51,11 @@ impl IbmClient {
             header::HeaderValue::from_static("application/json"),
         );
 
-        let client = Client::builder().default_headers(headers).build()?;
+        let client = Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(60))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()?;
 
         Ok(Self {
             client,

--- a/adapters/arvak-adapter-iqm/Cargo.toml
+++ b/adapters/arvak-adapter-iqm/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "api-bindings"]
 [dependencies]
 arvak-ir = { workspace = true }
 arvak-hal = { workspace = true }
-arvak-qasm3 = { path = "../../crates/arvak-qasm3" }
+arvak-qasm3 = { workspace = true }
 
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/adapters/arvak-adapter-iqm/src/api.rs
+++ b/adapters/arvak-adapter-iqm/src/api.rs
@@ -15,7 +15,7 @@ use tracing::{debug, instrument};
 use crate::error::{IqmError, IqmResult};
 
 /// IQM Resonance API client.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct IqmClient {
     /// HTTP client.
     client: Client,
@@ -23,6 +23,15 @@ pub struct IqmClient {
     base_url: String,
     /// Authentication token.
     token: String,
+}
+
+impl std::fmt::Debug for IqmClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IqmClient")
+            .field("base_url", &self.base_url)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl IqmClient {

--- a/adapters/arvak-adapter-qdmi/Cargo.toml
+++ b/adapters/arvak-adapter-qdmi/Cargo.toml
@@ -17,7 +17,7 @@ system-qdmi = []
 [dependencies]
 arvak-ir = { workspace = true }
 arvak-hal = { workspace = true }
-arvak-qasm3 = { path = "../../crates/arvak-qasm3" }
+arvak-qasm3 = { workspace = true }
 
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/adapters/arvak-adapter-sim/Cargo.toml
+++ b/adapters/arvak-adapter-sim/Cargo.toml
@@ -21,9 +21,7 @@ num-complex = { workspace = true }
 ndarray = { workspace = true }
 rustc-hash = { workspace = true }
 tracing = { workspace = true }
-# Note: rand is directly pinned because it is not a workspace dependency.
-# Consider adding rand to [workspace.dependencies] if other crates also need it.
-rand = "0.8"
+rand = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/arvak-bench/Cargo.toml
+++ b/crates/arvak-bench/Cargo.toml
@@ -11,7 +11,7 @@ arvak-ir.workspace = true
 arvak-compile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { workspace = true, features = ["small_rng"] }
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/arvak-cli/Cargo.toml
+++ b/crates/arvak-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 arvak-ir = { workspace = true }
-arvak-qasm3 = { path = "../arvak-qasm3" }
+arvak-qasm3 = { workspace = true }
 arvak-compile = { workspace = true }
 arvak-hal = { workspace = true }
 arvak-adapter-sim = { path = "../../adapters/arvak-adapter-sim" }
@@ -30,7 +30,7 @@ dirs = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yml = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
 indicatif = { workspace = true }
@@ -43,7 +43,7 @@ mimalloc = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 arvak-compile = { workspace = true }
-arvak-qasm3 = { path = "../arvak-qasm3" }
+arvak-qasm3 = { workspace = true }
 tempfile = "3"
 
 [features]

--- a/crates/arvak-compile/src/passes/agnostic/noise_injection.rs
+++ b/crates/arvak-compile/src/passes/agnostic/noise_injection.rs
@@ -94,7 +94,16 @@ impl Pass for NoiseInjectionPass {
             }
         }
 
-        // Apply injections
+        // Apply injections.
+        //
+        // TODO: Known limitation — noise channels are appended at the end of the
+        // DAG via `dag.apply()` rather than being inserted immediately after the
+        // target gate. In the DAG model, `apply()` always places the new node at
+        // the current wire front (just before the output node), so noise channels
+        // will appear after all pre-existing operations on that wire. This is
+        // semantically correct for single-wire circuits but may reorder operations
+        // relative to gates on other wires. A positional `insert_after(node, inst)`
+        // API on CircuitDag would be needed to fix this precisely.
         for inst in gate_injections {
             dag.apply(inst)?;
         }

--- a/crates/arvak-compile/src/passes/target/neutral_atom_routing.rs
+++ b/crates/arvak-compile/src/passes/target/neutral_atom_routing.rs
@@ -41,8 +41,11 @@ impl ZoneAssignment {
             self.zones > 0,
             "ZoneAssignment::zone_of called with zones == 0"
         );
+        if self.qubits_per_zone == 0 {
+            return 0;
+        }
         let z = qubit / self.qubits_per_zone;
-        z.min(self.zones - 1)
+        z.min(self.zones.saturating_sub(1))
     }
 
     /// Check if two physical qubits are in the same zone.

--- a/crates/arvak-compile/src/unitary.rs
+++ b/crates/arvak-compile/src/unitary.rs
@@ -296,17 +296,15 @@ impl Unitary2x2 {
     }
 
     /// Normalize angles to [-pi, pi].
-    pub fn normalize_angle(mut angle: f64) -> f64 {
+    pub fn normalize_angle(angle: f64) -> f64 {
         if angle.is_nan() || angle.is_infinite() {
             return 0.0;
         }
-        while angle > PI {
-            angle -= 2.0 * PI;
+        let mut a = angle.rem_euclid(2.0 * PI);
+        if a > PI {
+            a -= 2.0 * PI;
         }
-        while angle < -PI {
-            angle += 2.0 * PI;
-        }
-        angle
+        a
     }
 }
 

--- a/crates/arvak-dashboard/static/app.js
+++ b/crates/arvak-dashboard/static/app.js
@@ -731,10 +731,10 @@ async function visualizeCircuit() {
 
         // Update info bar
         infoBar.innerHTML = `
-            <span><span class="label">Name:</span> <span class="value">${circuit.name}</span></span>
-            <span><span class="label">Qubits:</span> <span class="value">${circuit.num_qubits}</span></span>
-            <span><span class="label">Depth:</span> <span class="value">${circuit.depth}</span></span>
-            <span><span class="label">Gates:</span> <span class="value">${circuit.num_ops}</span></span>
+            <span><span class="label">Name:</span> <span class="value">${escapeHtml(String(circuit.name))}</span></span>
+            <span><span class="label">Qubits:</span> <span class="value">${escapeHtml(String(circuit.num_qubits))}</span></span>
+            <span><span class="label">Depth:</span> <span class="value">${escapeHtml(String(circuit.depth))}</span></span>
+            <span><span class="label">Gates:</span> <span class="value">${escapeHtml(String(circuit.num_ops))}</span></span>
         `;
 
         // Render circuit
@@ -771,9 +771,9 @@ async function compileCircuit() {
 
         // Update main circuit info
         infoBar.innerHTML = `
-            <span><span class="label">Name:</span> <span class="value">${result.before.name}</span></span>
-            <span><span class="label">Target:</span> <span class="value">${target.toUpperCase()}</span></span>
-            <span><span class="label">Opt Level:</span> <span class="value">${optLevel}</span></span>
+            <span><span class="label">Name:</span> <span class="value">${escapeHtml(String(result.before.name))}</span></span>
+            <span><span class="label">Target:</span> <span class="value">${escapeHtml(target.toUpperCase())}</span></span>
+            <span><span class="label">Opt Level:</span> <span class="value">${escapeHtml(String(optLevel))}</span></span>
         `;
 
         // Render original circuit in main container
@@ -795,12 +795,12 @@ async function compileCircuit() {
             : `${(stats.throughput_gates_per_sec / 1000).toFixed(0)}K gates/s`;
 
         document.getElementById('compile-stats').innerHTML = `
-            <span><span class="label">Original Depth:</span> <span class="value">${stats.original_depth}</span></span>
-            <span><span class="label">Compiled Depth:</span> <span class="value ${depthChange < 0 ? 'improved' : depthChange > 0 ? 'degraded' : ''}">${stats.compiled_depth} (${depthChange >= 0 ? '+' : ''}${depthChange})</span></span>
-            <span><span class="label">Original Gates:</span> <span class="value">${stats.gates_before}</span></span>
-            <span><span class="label">Compiled Gates:</span> <span class="value ${gateChange < 0 ? 'improved' : gateChange > 0 ? 'degraded' : ''}">${stats.gates_after} (${gateChange >= 0 ? '+' : ''}${gateChange})</span></span>
-            <span><span class="label">Compile Time:</span> <span class="value improved">${timeStr}</span></span>
-            <span><span class="label">Throughput:</span> <span class="value improved">${throughputStr}</span></span>
+            <span><span class="label">Original Depth:</span> <span class="value">${escapeHtml(String(stats.original_depth))}</span></span>
+            <span><span class="label">Compiled Depth:</span> <span class="value ${depthChange < 0 ? 'improved' : depthChange > 0 ? 'degraded' : ''}">${escapeHtml(String(stats.compiled_depth))} (${depthChange >= 0 ? '+' : ''}${escapeHtml(String(depthChange))})</span></span>
+            <span><span class="label">Original Gates:</span> <span class="value">${escapeHtml(String(stats.gates_before))}</span></span>
+            <span><span class="label">Compiled Gates:</span> <span class="value ${gateChange < 0 ? 'improved' : gateChange > 0 ? 'degraded' : ''}">${escapeHtml(String(stats.gates_after))} (${gateChange >= 0 ? '+' : ''}${escapeHtml(String(gateChange))})</span></span>
+            <span><span class="label">Compile Time:</span> <span class="value improved">${escapeHtml(String(timeStr))}</span></span>
+            <span><span class="label">Throughput:</span> <span class="value improved">${escapeHtml(String(throughputStr))}</span></span>
         `;
 
         // Render before/after circuits
@@ -883,18 +883,18 @@ async function loadBackends() {
             card.style.cursor = 'pointer';
             card.innerHTML = `
                 <h3>
-                    ${backend.name}
+                    ${escapeHtml(backend.name)}
                     <span class="status ${backend.available ? 'available' : 'unavailable'}"></span>
                 </h3>
                 <div class="info">
                     <span><strong>Type:</strong> ${backend.is_simulator ? 'Simulator' : 'Hardware'}</span>
-                    <span><strong>Qubits:</strong> ${backend.num_qubits}</span>
+                    <span><strong>Qubits:</strong> ${escapeHtml(String(backend.num_qubits))}</span>
                     <span><strong>Status:</strong> ${backend.available ? 'Available' : 'Unavailable'}</span>
                 </div>
                 <div class="gates">
                     <strong>Native gates:</strong>
                     ${backend.native_gates.length > 0
-                        ? backend.native_gates.map(g => `<span class="tag">${g}</span>`).join('')
+                        ? backend.native_gates.map(g => `<span class="tag">${escapeHtml(g)}</span>`).join('')
                         : '<span class="tag">universal</span>'}
                 </div>
             `;
@@ -927,12 +927,12 @@ async function showBackendTopology(name) {
         }
     } catch (error) {
         detailContainer.style.display = 'block';
-        topoContainer.innerHTML = `<div class="error-message">${error.message}</div>`;
+        topoContainer.innerHTML = `<div class="error-message">${escapeHtml(error.message)}</div>`;
     }
 }
 
 function showError(container, message) {
-    container.innerHTML = `<div class="error-message">${message}</div>`;
+    container.innerHTML = `<div class="error-message">${escapeHtml(message)}</div>`;
 }
 
 // ============================================================================
@@ -1027,15 +1027,15 @@ async function viewJobDetails(jobId) {
                 <div class="job-details-grid">
                     <div class="detail-item">
                         <span class="label">Job ID</span>
-                        <span class="value">${job.id}</span>
+                        <span class="value">${escapeHtml(job.id)}</span>
                     </div>
                     <div class="detail-item">
                         <span class="label">Status</span>
-                        <span class="value">${job.status}${job.status_details ? ' - ' + escapeHtml(job.status_details) : ''}</span>
+                        <span class="value">${escapeHtml(job.status)}${job.status_details ? ' - ' + escapeHtml(job.status_details) : ''}</span>
                     </div>
                     <div class="detail-item">
                         <span class="label">Backend</span>
-                        <span class="value">${job.backend || 'Not assigned'}</span>
+                        <span class="value">${escapeHtml(job.backend || 'Not assigned')}</span>
                     </div>
                     <div class="detail-item">
                         <span class="label">Shots</span>
@@ -1074,7 +1074,7 @@ async function viewJobDetails(jobId) {
                 ${Object.keys(job.metadata || {}).length > 0 ? `
                 <div class="job-metadata">
                     <h4>Metadata</h4>
-                    <pre>${JSON.stringify(job.metadata, null, 2)}</pre>
+                    <pre>${escapeHtml(JSON.stringify(job.metadata, null, 2))}</pre>
                 </div>` : ''}
 
                 <div class="job-actions-panel">
@@ -1118,7 +1118,7 @@ async function viewJobResult(jobId) {
                     <span><strong>Total Shots:</strong> ${result.statistics.total_shots}</span>
                     <span><strong>Unique Outcomes:</strong> ${result.statistics.unique_outcomes}</span>
                     ${result.execution_time_ms ? `<span><strong>Execution Time:</strong> ${result.execution_time_ms}ms</span>` : ''}
-                    <span><strong>Most Frequent:</strong> ${result.statistics.most_frequent} (${result.statistics.most_frequent_count} times)</span>
+                    <span><strong>Most Frequent:</strong> ${escapeHtml(String(result.statistics.most_frequent))} (${result.statistics.most_frequent_count} times)</span>
                 </div>
 
                 <div id="histogram-container" class="histogram-container"></div>
@@ -1136,7 +1136,7 @@ async function viewJobResult(jobId) {
                         <tbody>
                             ${result.bars.slice(0, 20).map(bar => `
                                 <tr>
-                                    <td class="mono">${bar.bitstring}</td>
+                                    <td class="mono">${escapeHtml(bar.bitstring)}</td>
                                     <td>${bar.count}</td>
                                     <td>${(bar.probability * 100).toFixed(2)}%</td>
                                 </tr>
@@ -1153,7 +1153,7 @@ async function viewJobResult(jobId) {
         // Render histogram with D3
         renderHistogram(document.getElementById('histogram-container'), result.bars);
     } catch (error) {
-        container.innerHTML = `<div class="error-message">${error.message}</div>`;
+        container.innerHTML = `<div class="error-message">${escapeHtml(error.message)}</div>`;
     }
 }
 

--- a/crates/arvak-eval/Cargo.toml
+++ b/crates/arvak-eval/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["science", "compilers"]
 
 [dependencies]
 arvak-ir = { workspace = true }
-arvak-qasm3 = { path = "../arvak-qasm3" }
+arvak-qasm3 = { workspace = true }
 arvak-compile = { workspace = true }
 arvak-hal = { workspace = true }
 

--- a/crates/arvak-grpc/Cargo.toml
+++ b/crates/arvak-grpc/Cargo.toml
@@ -20,7 +20,7 @@ prost-types = "0.13"
 tokio = { workspace = true, features = ["net", "signal", "io-util"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 async-trait = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 
 # Arvak core
 arvak-hal = { workspace = true }
@@ -45,7 +45,7 @@ chrono = { workspace = true, features = ["serde"] }
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.9"
+serde_yml = { workspace = true }
 
 # Configuration
 dotenvy = "0.15"

--- a/crates/arvak-grpc/src/config.rs
+++ b/crates/arvak-grpc/src/config.rs
@@ -302,7 +302,7 @@ impl Config {
             .map_err(|e| ConfigError::IoError(e.to_string()))?;
 
         let config: Config =
-            serde_yaml::from_str(&contents).map_err(|e| ConfigError::ParseError(e.to_string()))?;
+            serde_yml::from_str(&contents).map_err(|e| ConfigError::ParseError(e.to_string()))?;
 
         config.validate()?;
         Ok(config)

--- a/crates/arvak-hal/src/capability.rs
+++ b/crates/arvak-hal/src/capability.rs
@@ -128,6 +128,9 @@ pub struct GateSet {
     pub single_qubit: Vec<String>,
     /// Two-qubit gates supported.
     pub two_qubit: Vec<String>,
+    /// Three-qubit gates supported.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub three_qubit: Vec<String>,
     /// Native gates (execute without decomposition on this backend).
     pub native: Vec<String>,
 }
@@ -138,6 +141,7 @@ impl GateSet {
         Self {
             single_qubit: vec!["prx".into()],
             two_qubit: vec!["cz".into()],
+            three_qubit: vec![],
             native: vec!["prx".into(), "cz".into()],
         }
     }
@@ -147,6 +151,7 @@ impl GateSet {
         Self {
             single_qubit: vec!["rz".into(), "sx".into(), "x".into(), "id".into()],
             two_qubit: vec!["cx".into()],
+            three_qubit: vec![],
             native: vec!["rz".into(), "sx".into(), "x".into(), "cx".into()],
         }
     }
@@ -188,6 +193,7 @@ impl GateSet {
                 "ryy".into(),
                 "rzz".into(),
             ],
+            three_qubit: vec!["ccx".into(), "cswap".into()],
             native: vec![],
         }
     }
@@ -199,13 +205,16 @@ impl GateSet {
         Self {
             single_qubit: vec!["rz".into(), "rx".into(), "ry".into()],
             two_qubit: vec!["cz".into()],
+            three_qubit: vec![],
             native: vec!["rz".into(), "rx".into(), "ry".into(), "cz".into()],
         }
     }
 
-    /// Check if a gate is supported (single-qubit or two-qubit).
+    /// Check if a gate is supported (single-qubit, two-qubit, or three-qubit).
     pub fn contains(&self, gate: &str) -> bool {
-        self.single_qubit.iter().any(|g| g == gate) || self.two_qubit.iter().any(|g| g == gate)
+        self.single_qubit.iter().any(|g| g == gate)
+            || self.two_qubit.iter().any(|g| g == gate)
+            || self.three_qubit.iter().any(|g| g == gate)
     }
 
     /// Check if a gate is native (executes without decomposition).
@@ -473,6 +482,7 @@ mod tests {
         let gs = GateSet {
             single_qubit: vec!["h".into(), "rx".into()],
             two_qubit: vec!["cx".into()],
+            three_qubit: vec![],
             native: vec!["rx".into(), "cx".into()],
         };
         assert!(gs.is_native("rx"));
@@ -485,6 +495,7 @@ mod tests {
         let gs = GateSet {
             single_qubit: vec!["h".into()],
             two_qubit: vec!["cx".into()],
+            three_qubit: vec![],
             native: vec![],
         };
         // When native is empty, all supported gates are native

--- a/crates/arvak-ir/src/gate.rs
+++ b/crates/arvak-ir/src/gate.rs
@@ -278,10 +278,14 @@ impl CustomGate {
     }
 
     /// Add a unitary matrix to the gate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `matrix.len()` does not equal `(2^num_qubits)^2`.
     #[must_use]
     pub fn with_matrix(mut self, matrix: Vec<Complex64>) -> Self {
         let dim = 1usize << self.num_qubits;
-        debug_assert_eq!(
+        assert_eq!(
             matrix.len(),
             dim * dim,
             "Matrix length {} does not match expected {} for {}-qubit gate",

--- a/crates/arvak-python/src/simulate.rs
+++ b/crates/arvak-python/src/simulate.rs
@@ -56,6 +56,10 @@ pub fn run_sim(circuit: &PyCircuit, shots: u32, py: Python<'_>) -> PyResult<Py<P
         let circuit_clone = circuit.inner.clone();
         let result = py.detach(move || backend.run_simulation(&circuit_clone, shots));
 
+        let result = result.map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("Simulation failed: {e}"))
+        })?;
+
         // Convert Counts → Python dict
         let dict = PyDict::new(py);
         for (bitstring, count) in result.counts.iter() {

--- a/crates/arvak-qdmi/Cargo.toml
+++ b/crates/arvak-qdmi/Cargo.toml
@@ -9,11 +9,10 @@ repository.workspace = true
 
 [dependencies]
 libloading.workspace = true
-log = "0.4"
+tracing = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-env_logger = "0.11"
 tempfile = "3"
 
 [features]

--- a/crates/arvak-qdmi/src/capabilities.rs
+++ b/crates/arvak-qdmi/src/capabilities.rs
@@ -306,7 +306,7 @@ fn query_sites(session: &DeviceSession<'_>) -> Result<Vec<SiteId>> {
         })
         .collect();
 
-    log::debug!("queried {} sites from device", sites.len());
+    tracing::debug!("queried {} sites from device", sites.len());
     Ok(sites)
 }
 
@@ -318,7 +318,7 @@ fn query_coupling_map(session: &DeviceSession<'_>) -> Result<CouplingMap> {
     let buf = match session.raw_query_device_property(ffi::QDMI_DEVICE_PROPERTY_COUPLINGMAP) {
         Ok(b) => b,
         Err(QdmiError::NotSupported) => {
-            log::warn!("device does not report a coupling map");
+            tracing::warn!("device does not report a coupling map");
             return Ok(CouplingMap::default());
         }
         Err(e) => return Err(e),
@@ -351,7 +351,7 @@ fn query_coupling_map(session: &DeviceSession<'_>) -> Result<CouplingMap> {
         pairs.push((a, b));
     }
 
-    log::debug!("queried coupling map with {} edges", pairs.len());
+    tracing::debug!("queried coupling map with {} edges", pairs.len());
     Ok(CouplingMap::from_pairs(pairs))
 }
 
@@ -379,7 +379,7 @@ fn query_operations(session: &DeviceSession<'_>) -> Result<Vec<OperationId>> {
         })
         .collect();
 
-    log::debug!("queried {} operations from device", ops.len());
+    tracing::debug!("queried {} operations from device", ops.len());
     Ok(ops)
 }
 
@@ -518,7 +518,7 @@ fn query_supported_formats(session: &DeviceSession<'_>) -> Vec<CircuitFormat> {
     {
         let int_size = std::mem::size_of::<i32>();
         if buf.len() % int_size != 0 || buf.is_empty() {
-            log::warn!(
+            tracing::warn!(
                 "supported program formats buffer has unexpected size {}; falling back",
                 buf.len()
             );
@@ -534,14 +534,16 @@ fn query_supported_formats(session: &DeviceSession<'_>) -> Vec<CircuitFormat> {
             })
             .collect();
         if formats.is_empty() {
-            log::warn!("device reported formats but none are supported by Arvak; falling back");
+            tracing::warn!("device reported formats but none are supported by Arvak; falling back");
             vec![CircuitFormat::OpenQasm3]
         } else {
-            log::debug!("device supports formats: {formats:?}");
+            tracing::debug!("device supports formats: {formats:?}");
             formats
         }
     } else {
-        log::debug!("device does not report supported program formats; defaulting to OpenQASM 3");
+        tracing::debug!(
+            "device does not report supported program formats; defaulting to OpenQASM 3"
+        );
         vec![CircuitFormat::OpenQasm3]
     }
 }

--- a/crates/arvak-qdmi/src/session.rs
+++ b/crates/arvak-qdmi/src/session.rs
@@ -93,7 +93,7 @@ impl<'dev> DeviceSession<'dev> {
             )));
         }
 
-        log::debug!(
+        tracing::debug!(
             "opened session on device '{}' (handle {:?})",
             device.prefix(),
             handle
@@ -446,7 +446,7 @@ impl Drop for DeviceSession<'_> {
     fn drop(&mut self) {
         if !self.handle.is_null() {
             unsafe { (self.device.fn_session_free)(self.handle) };
-            log::debug!("freed session on device '{}'", self.device.prefix());
+            tracing::debug!("freed session on device '{}'", self.device.prefix());
         }
     }
 }
@@ -588,7 +588,7 @@ impl Drop for DeviceJob<'_, '_> {
     fn drop(&mut self) {
         if let Some(free_fn) = self.session.device.fn_job_free {
             unsafe { free_fn(self.handle) };
-            log::debug!("freed job on device '{}'", self.session.device.prefix());
+            tracing::debug!("freed job on device '{}'", self.session.device.prefix());
         }
     }
 }

--- a/crates/arvak-sched/src/matcher.rs
+++ b/crates/arvak-sched/src/matcher.rs
@@ -345,6 +345,7 @@ mod tests {
                 gate_set: GateSet {
                     single_qubit: vec!["h".to_string(), "x".to_string()],
                     two_qubit: vec!["cx".to_string()],
+                    three_qubit: vec![],
                     native: vec![],
                 },
                 topology: Topology {

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -32,8 +32,7 @@ tracing-subscriber = { workspace = true }
 num-complex = { workspace = true }
 
 # Random for parameter initialization
-# Note: Direct version pin; consider workspace dependency
-rand = "0.8"
+rand = { workspace = true }
 
 [[bin]]
 name = "demo-grover"

--- a/demos/lumi-hybrid/Cargo.toml
+++ b/demos/lumi-hybrid/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "lumi-hybrid"
-version = "1.0.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "LUMI-Q Quantum-HPC Hybrid Demo: VQE for H2 molecule"
-license = "Apache-2.0"
+license.workspace = true
 publish = false
 
 [[bin]]
@@ -15,21 +16,21 @@ name = "quantum_worker"
 path = "src/quantum_worker.rs"
 
 [dependencies]
-arvak-ir = { path = "../../crates/arvak-ir" }
-arvak-qasm3 = { path = "../../crates/arvak-qasm3" }
-arvak-hal = { path = "../../crates/arvak-hal" }
-arvak-compile = { path = "../../crates/arvak-compile" }
-arvak-sched = { path = "../../crates/arvak-sched" }
-arvak-adapter-sim = { path = "../../adapters/arvak-adapter-sim" }
+arvak-ir = { workspace = true }
+arvak-qasm3 = { workspace = true }
+arvak-hal = { workspace = true }
+arvak-compile = { workspace = true }
+arvak-sched = { workspace = true }
+arvak-adapter-sim = { workspace = true }
 arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm" }
 
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-anyhow = "1"
-clap = { version = "4", features = ["derive"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/demos/lumi-hybrid/src/main.rs
+++ b/demos/lumi-hybrid/src/main.rs
@@ -314,7 +314,9 @@ async fn evaluate_energy(
         "iqm" | "lumi" => {
             // For real hardware, we'd use the IQM adapter
             // For now, fall back to exact simulation
-            warn!("IQM/LUMI backend: using exact simulation (connect to real hardware with IQM_TOKEN)");
+            warn!(
+                "IQM/LUMI backend: using exact simulation (connect to real hardware with IQM_TOKEN)"
+            );
             Ok(hamiltonian.exact_energy_for_parameter(theta))
         }
         _ => {

--- a/demos/lumi-hybrid/src/optimizer.rs
+++ b/demos/lumi-hybrid/src/optimizer.rs
@@ -612,7 +612,7 @@ impl SpsaOptimizer {
             let mut hasher = DefaultHasher::new();
             (self.iteration, i).hash(&mut hasher);
             let hash = hasher.finish();
-            let sign = if hash.is_multiple_of(2) { 1.0 } else { -1.0 };
+            let sign = if hash % 2 == 0 { 1.0 } else { -1.0 };
             self.delta.push(sign);
         }
     }


### PR DESCRIPTION
## Summary

Two-cycle deep audit (Double Knuth) of the entire Arvak codebase — 8 parallel inspection agents read every file, followed by automated fixes and regression verification.

- **Cycle 1**: Found 130 findings (11 critical, 35 high, 48 medium, 36 low). Applied 39 fixes.
- **Cycle 2**: Re-audited the modified codebase. Found 4 new regressions (2 critical — fixed immediately), 7 persistent issues (all fixed), 52 pre-existing items (6 more fixed).
- **Total fixes**: 51 across 44 files (+787 / -369 lines)

### Security (7 fixes)
- XSS: all `innerHTML` injections now pass through `escapeHtml()`
- CORS: configurable via `ARVAK_CORS_ORIGIN` env var with graceful fallback
- Token cache: atomic file creation with `mode(0o600)` — no TOCTOU race
- CI: `permissions: contents: read` added to `ci.yml`
- IBM adapter: HTTP client now has 60s request + 10s connect timeouts
- IQM client: `Debug` impl redacts API token
- Simulator: custom gates return errors instead of silently producing wrong results

### Correctness (18 fixes)
- `Circuit::from_dag`: uses `max(id)+1` with `checked_add` — no more ID collisions
- `Counts`: `FromIterator`, `from_pairs`, and `insert` all accumulate consistently
- `most_frequent`: guarded against division by zero
- `ZoneAssignment::zone_of`: guarded against division by zero
- `normalize_angle`: O(1) via `rem_euclid` (was O(n) while loop)
- IBM: actual shot count from metadata, `hex_to_binary` takes `num_qubits`
- Simulator: `Result` propagation for unresolved params + `spawn_blocking`
- IQM: `tokio::sync::Mutex` for async safety
- QDMI: `usize` for `HistValues`, `Drop` handles poisoned locks
- Gate set validation added to `validate()` in IBM, IQM, QDMI
- `GateSet`: three-qubit gate support (`ccx`, `cswap`)
- `ResourceManager`: enforces `max_concurrent_jobs`, per-job batch checks
- Backend info caches expire after 5 minutes; job caches evict at 10k

### Dependencies (6 fixes)
- `serde_yaml` → `serde_yml` (RUSTSEC-2024-0320)
- `arvak-qdmi`: `log` → `tracing`
- Unified workspace deps: `arvak-qasm3`, `rand`, `futures`
- `lumi-hybrid` aligned with workspace edition/version/rust-version
- Removed vestigial `env_logger`

### Build & CI (4 fixes)
- CI clippy strictness aligned between `ci.yml` and `nightly.yml`
- Dockerfile: added `arvak-qdmi` + speed-demo stubs for layer caching
- Fixed `lumi-hybrid` MSRV compat (`is_multiple_of` → `% 2 == 0`)

### Documentation
- Added audit-derived coding rules to `CLAUDE.md`

## Verification

- `cargo check --workspace --exclude arvak-python` — clean
- `cargo test --workspace --exclude arvak-python` — all pass, 0 failures
- `cargo clippy` (strict pedantic, matching nightly CI) — 0 warnings

## Test plan

- [x] Workspace compiles with zero errors
- [x] All existing tests pass (no regressions)
- [x] Strict pedantic clippy clean
- [ ] Verify dashboard CORS works with `ARVAK_CORS_ORIGIN` set
- [ ] Verify `escapeHtml` doesn't break normal dashboard rendering
- [ ] Spot-check IBM/IQM adapter behavior with real backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)