### PR TITLE
RFC-0001 Phase 1: native HAL backend bridge + Qiskit-2.4 housekeeping + GH actions Node-24 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -38,7 +38,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -80,10 +80,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -98,7 +98,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -172,10 +172,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -194,7 +194,7 @@ jobs:
         run: brew install protobuf
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -216,10 +216,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -241,10 +241,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -259,7 +259,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -275,10 +275,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -289,7 +289,7 @@ jobs:
           toolchain: nightly-2026-02-09
 
       - name: Cache cargo-audit
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-0.22.1-${{ runner.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,10 +32,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -47,7 +47,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/cargo-audit
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dependency-checks
           path: |
@@ -170,10 +170,10 @@ jobs:
             profile: release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -193,7 +193,7 @@ jobs:
         run: brew install protobuf
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -234,10 +234,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -252,7 +252,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -326,10 +326,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -346,7 +346,7 @@ jobs:
           sudo apt-get install -y cmake ninja-build libboost-dev nlohmann-json3-dev libspdlog-dev
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -357,7 +357,7 @@ jobs:
             nightly-${{ runner.os }}-ddsim-
 
       - name: Cache DDSIM build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build-ddsim
           key: ddsim-pinned-v3.4.1-${{ runner.os }}-${{ hashFiles('crates/arvak-qdmi/ci/ddsim_shim/CMakeLists.txt') }}
@@ -432,10 +432,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -449,7 +449,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -475,10 +475,10 @@ jobs:
         python-version: ['3.11', '3.13']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -493,7 +493,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -524,7 +524,7 @@ jobs:
           "
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: arvak-wheel-py${{ matrix.python-version }}
           path: |
@@ -540,10 +540,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -558,7 +558,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -578,7 +578,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: benchmarks
           path: bench-output.txt
@@ -592,10 +592,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -610,7 +610,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -645,7 +645,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-reports
           path: |
@@ -667,10 +667,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -698,10 +698,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -738,10 +738,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -793,7 +793,7 @@ jobs:
           chmod +x ~/.ssh/ssh_retry.sh
 
       - name: Download Python wheel artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: arvak-wheel-py3.11
           path: wheel-artifact
@@ -952,10 +952,10 @@ jobs:
     needs: [python-bindings]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout hal-contract (workspace path dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
           path: .hal-contract
@@ -970,7 +970,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -1031,7 +1031,7 @@ jobs:
       - notebook-tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure labels exist
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         target: [x86_64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -34,7 +34,7 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: '1'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheels-linux-${{ matrix.target }}
           path: crates/arvak-python/dist
@@ -48,8 +48,8 @@ jobs:
   #         - x86_64-unknown-linux-musl
   #         - aarch64-unknown-linux-musl
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
+  #     - uses: actions/checkout@v5
+  #     - uses: actions/setup-python@v6
   #       with:
   #         python-version: '3.13'
   #     - name: Build wheels
@@ -63,7 +63,7 @@ jobs:
   #       env:
   #         PYO3_USE_ABI3_FORWARD_COMPATIBILITY: '1'
   #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: wheels-musllinux-${{ matrix.target }}
   #         path: crates/arvak-python/dist
@@ -74,9 +74,9 @@ jobs:
       matrix:
         target: [x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           architecture: ${{ matrix.target }}
@@ -92,7 +92,7 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: '1'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheels-windows-${{ matrix.target }}
           path: crates/arvak-python/dist
@@ -103,9 +103,9 @@ jobs:
       matrix:
         target: [aarch64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -120,7 +120,7 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: '1'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheels-macos-${{ matrix.target }}
           path: crates/arvak-python/dist
@@ -128,7 +128,7 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1
@@ -138,7 +138,7 @@ jobs:
           working-directory: crates/arvak-python
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheels-sdist
           path: crates/arvak-python/dist
@@ -147,7 +147,7 @@ jobs:
     name: QDMI Device Library (Linux x86_64)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -162,7 +162,7 @@ jobs:
         run: cp target/release/libarvak_qdmi_device.so libqdmi_arvak.so
 
       - name: Upload QDMI library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qdmi-linux-x86_64
           path: libqdmi_arvak.so
@@ -171,7 +171,7 @@ jobs:
     name: QDMI Device Library (macOS ARM)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -186,7 +186,7 @@ jobs:
         run: cp target/release/libarvak_qdmi_device.dylib libqdmi_arvak.dylib
 
       - name: Upload QDMI library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qdmi-macos-aarch64
           path: libqdmi_arvak.dylib
@@ -200,7 +200,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "num-complex",
  "pyo3",
  "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -25,3 +25,4 @@ arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }
 rand = { workspace = true }
+tokio = { workspace = true }

--- a/crates/arvak-python/notebooks/02_qiskit_integration.ipynb
+++ b/crates/arvak-python/notebooks/02_qiskit_integration.ipynb
@@ -19,7 +19,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import arvak\n\n# Verify Qiskit integration is available\nstatus = arvak.integration_status()\nprint(\"Available integrations:\")\nfor name, info in status.items():\n    icon = \"✓\" if info['available'] else \"✗\"\n    print(f\"  {icon} {name}: {info['packages']}\")\n\n# Check specifically for Qiskit\nif 'qiskit' not in status or not status['qiskit']['available']:\n    raise ImportError(\n        \"Qiskit integration not available. \"\n        \"Install with: pip install qiskit>=1.0.0 qiskit-aer>=0.13.0\"\n    )\n\nprint(\"\\n✓ Qiskit integration is available!\")"
+   "source": "import arvak\n\n# Verify Qiskit integration is available\nstatus = arvak.integration_status()\nprint(\"Available integrations:\")\nfor name, info in status.items():\n    icon = \"✓\" if info['available'] else \"✗\"\n    print(f\"  {icon} {name}: {info['packages']}\")\n\n# Check specifically for Qiskit\nif 'qiskit' not in status or not status['qiskit']['available']:\n    raise ImportError(\n        \"Qiskit integration not available. \"\n        \"Install with: pip install qiskit>=2.0.0 qiskit-aer>=0.17.0\"\n    )\n\nprint(\"\\n✓ Qiskit integration is available!\")"
   },
   {
    "cell_type": "markdown",

--- a/crates/arvak-python/pyproject.toml
+++ b/crates/arvak-python/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov"]
 # Framework integrations (optional)
-qiskit = ["qiskit>=1.0.0", "qiskit-aer>=0.13.0", "qiskit-qasm3-import>=0.5.0"]
+qiskit = ["qiskit>=2.0.0", "qiskit-aer>=0.17.0", "qiskit-qasm3-import>=0.5.0"]
 qrisp = ["qrisp>=0.4.0"]
 cirq = ["cirq>=1.0.0", "cirq-core>=1.0.0", "ply>=3.11"]
 pennylane = ["pennylane>=0.32.0"]

--- a/crates/arvak-python/python/arvak/__init__.py
+++ b/crates/arvak-python/python/arvak/__init__.py
@@ -42,6 +42,16 @@ from arvak._native import (
     run_tebd,
     # Compilation
     compile,
+    # Native backend bridge (HAL Backend trait via PyO3)
+    Backend,
+    JobHandle,
+    Capabilities,
+    Availability,
+    ValidationResult,
+    JobStatus,
+    ExecutionResult,
+    backend_for,
+    list_backends,
 )
 
 # Import integration registry
@@ -181,6 +191,16 @@ __all__ = [
     "run_tebd",
     # Compilation
     "compile",
+    # Native backend bridge
+    "Backend",
+    "JobHandle",
+    "Capabilities",
+    "Availability",
+    "ValidationResult",
+    "JobStatus",
+    "ExecutionResult",
+    "backend_for",
+    "list_backends",
     # Integration API
     "list_integrations",
     "integration_status",

--- a/crates/arvak-python/python/arvak/__init__.py
+++ b/crates/arvak-python/python/arvak/__init__.py
@@ -102,7 +102,7 @@ def integration_status():
     Example:
         >>> status = arvak.integration_status()
         >>> print(status['qiskit'])
-        {'name': 'qiskit', 'available': True, 'packages': ['qiskit>=1.0.0']}
+        {'name': 'qiskit', 'available': True, 'packages': ['qiskit>=2.0.0']}
     """
     return IntegrationRegistry.status()
 

--- a/crates/arvak-python/python/arvak/integrations/qiskit/__init__.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/__init__.py
@@ -41,7 +41,7 @@ class QiskitIntegration(FrameworkIntegration):
     @property
     def required_packages(self) -> list[str]:
         """Required packages for this integration."""
-        return ["qiskit>=1.0.0"]
+        return ["qiskit>=2.0.0"]
 
     def is_available(self) -> bool:
         """Check if Qiskit is installed."""

--- a/crates/arvak-python/python/arvak/integrations/qiskit/__init__.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/__init__.py
@@ -92,9 +92,9 @@ if _integration.is_available():
     IntegrationRegistry.register(_integration)
 
     # Expose public API at package level
-    from .backend import ArvakProvider
+    from .backend import ArvakProvider, ArvakBackend
     from .converter import qiskit_to_arvak, arvak_to_qiskit
 
-    __all__ = ['ArvakProvider', 'qiskit_to_arvak', 'arvak_to_qiskit', 'QiskitIntegration']
+    __all__ = ['ArvakProvider', 'ArvakBackend', 'qiskit_to_arvak', 'arvak_to_qiskit', 'QiskitIntegration']
 else:
     __all__ = ['QiskitIntegration']

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -269,7 +269,9 @@ class ArvakProvider:
             List of backend instances
         """
         if not self._backends:
-            self._backends['sim'] = ArvakSimulatorBackend(provider=self)
+            # Native HAL-backed simulator (replaces ArvakSimulatorBackend as of v2.0).
+            # See docs/RFC/0001-native-backend-unification.md.
+            self._backends['sim'] = ArvakBackend(provider=self, backend_name='sim')
 
         # Lazily create IBM backends on demand
         if name and name in self._IBM_BACKENDS and name not in self._backends:
@@ -385,8 +387,126 @@ class ArvakProvider:
         return f"<ArvakProvider(backends={list(self._backends.keys())})>"
 
 
+def _qiskit_to_qasm3(qc) -> str:
+    """Serialize a Qiskit circuit to QASM3 (with QASM2 fallback)."""
+    try:
+        from qiskit.qasm3 import dumps
+        return dumps(qc)
+    except (ImportError, AttributeError):
+        from qiskit.qasm2 import dumps as dumps2
+        return dumps2(qc)
+
+
+class ArvakBackend:
+    """Native Arvak backend, Qiskit-compatible.
+
+    Wraps an ``arvak.Backend`` from the PyO3 layer (which in turn wraps any
+    ``arvak_hal::Backend`` adapter — sim, IQM, IBM, etc.). The Qiskit-shaped
+    surface (``.name``, ``.num_qubits``, ``.basis_gates``, ``.coupling_map``,
+    ``.run()``) is provided here so existing callers continue to work; all
+    actual work happens in the native Rust adapter through a single code
+    path.
+
+    Use ``ArvakProvider().get_backend(name)`` to obtain instances — do not
+    construct directly.
+
+    See ``docs/RFC/0001-native-backend-unification.md`` for the architecture.
+    """
+
+    def __init__(self, provider: ArvakProvider, backend_name: str):
+        import arvak  # imported lazily — arvak.Backend is from the PyO3 layer
+
+        self._provider = provider
+        self._native = arvak.backend_for(backend_name)
+        # Qiskit-compatible metadata
+        self.name = self._native.name
+        self.description = f"Arvak native backend '{self.name}'"
+        self.backend_version = '2.0.0'
+        # Kept for backwards-compat with ArvakSimulatorBackend's surface — some
+        # Qiskit-shaped callers introspect this. No semantic meaning beyond
+        # "this backend type exists".
+        self.online_date = '2024-01-01'
+
+    @property
+    def max_circuits(self) -> Optional[int]:
+        return None
+
+    @property
+    def num_qubits(self) -> int:
+        return self._native.num_qubits
+
+    @property
+    def basis_gates(self) -> list[str]:
+        return list(self._native.basis_gates)
+
+    @property
+    def coupling_map(self) -> Optional[list[list[int]]]:
+        cm = self._native.coupling_map
+        if cm is None:
+            return None
+        return [[a, b] for (a, b) in cm]
+
+    def capabilities(self):
+        """Return the underlying ``arvak.Capabilities`` (HAL view)."""
+        return self._native.capabilities()
+
+    def availability(self):
+        """Query backend availability (returns ``arvak.Availability``)."""
+        return self._native.availability()
+
+    def validate(self, circuit) -> 'arvak.ValidationResult':
+        """Validate a Qiskit circuit against backend constraints.
+
+        Returns an ``arvak.ValidationResult`` from the HAL layer with three
+        possible states: valid, invalid (with reasons), or requires
+        transpilation. Use ``bool(result)`` for a quick valid/invalid check.
+
+        Args:
+            circuit: A single Qiskit ``QuantumCircuit``.
+
+        Returns:
+            ``arvak.ValidationResult`` — supports ``bool()``, ``.valid``,
+            ``.reasons``, ``.requires_transpilation``, ``.details``.
+        """
+        qasm = _qiskit_to_qasm3(circuit)
+        return self._native.validate(qasm)
+
+    def run(self, circuits, shots: int = 1024, **options) -> 'ArvakJob':
+        """Submit one or many Qiskit circuits and block until results are in.
+
+        Args:
+            circuits: A single Qiskit ``QuantumCircuit`` or a list of them.
+            shots: Number of measurement shots (default: 1024).
+
+        Returns:
+            An ``ArvakJob`` whose ``.result().get_counts(idx)`` returns the
+            measurement counts for circuit *idx* (defaults to 0).
+        """
+        if not isinstance(circuits, list):
+            circuits = [circuits]
+
+        parameters = options.get('parameters')  # forwarded to HAL submit()
+
+        all_counts: list[dict[str, int]] = []
+        for qc in circuits:
+            qasm = _qiskit_to_qasm3(qc)
+            exec_result = self._native.run(qasm, shots, parameters)
+            all_counts.append(dict(exec_result.counts))
+
+        return ArvakJob(backend=self, counts=all_counts, shots=shots)
+
+    def __repr__(self) -> str:
+        return f"<ArvakBackend('{self.name}')>"
+
+
 class ArvakSimulatorBackend:
     """Arvak simulator backend with Qiskit-compatible interface.
+
+    .. deprecated:: 2.0
+        Use :class:`ArvakBackend` instead. ``ArvakProvider.get_backend('sim')``
+        now returns the new native-backed class automatically. Direct
+        instantiation of this class still works but will be removed in a
+        future release. See ``docs/RFC/0001-native-backend-unification.md``.
 
     Wraps Arvak's built-in Rust statevector simulator. Circuits are converted
     to OpenQASM 3, compiled and simulated in Rust, and results are returned
@@ -396,6 +516,14 @@ class ArvakSimulatorBackend:
     """
 
     def __init__(self, provider: ArvakProvider):
+        import warnings
+        warnings.warn(
+            "ArvakSimulatorBackend is deprecated; ArvakProvider.get_backend('sim') "
+            "now returns ArvakBackend (native HAL-backed). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._provider = provider
         self.name = 'arvak_simulator'
         self.description = 'Arvak Rust statevector simulator'
@@ -440,14 +568,7 @@ class ArvakSimulatorBackend:
         # Execute each circuit on the simulator
         all_counts = []
         for qc in circuits:
-            # Convert Qiskit circuit to QASM → Arvak circuit
-            try:
-                from qiskit.qasm3 import dumps
-                qasm_str = dumps(qc)
-            except (ImportError, AttributeError):
-                from qiskit.qasm2 import dumps as dumps2
-                qasm_str = dumps2(qc)
-
+            qasm_str = _qiskit_to_qasm3(qc)
             arvak_circuit = arvak.from_qasm(qasm_str)
             counts = arvak.run_sim(arvak_circuit, shots)
             all_counts.append(counts)

--- a/crates/arvak-python/python/arvak/integrations/qiskit/converter.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/converter.py
@@ -39,7 +39,7 @@ def qiskit_to_arvak(circuit: 'QuantumCircuit') -> 'arvak.Circuit':
     except ImportError:
         raise ImportError(
             "Qiskit is required for this operation. "
-            "Install with: pip install qiskit>=1.0.0"
+            "Install with: pip install qiskit>=2.0.0"
         )
 
     import arvak
@@ -80,7 +80,7 @@ def arvak_to_qiskit(circuit: 'arvak.Circuit') -> 'QuantumCircuit':
     except ImportError:
         raise ImportError(
             "Qiskit is required for this operation. "
-            "Install with: pip install qiskit>=1.0.0"
+            "Install with: pip install qiskit>=2.0.0"
         )
 
     import arvak

--- a/crates/arvak-python/python/arvak/nathan/bench.py
+++ b/crates/arvak-python/python/arvak/nathan/bench.py
@@ -37,7 +37,7 @@ class BenchReference:
 # Static table — representative MQT Bench entries (algorithm × qubit counts)
 # Generated from MQT Bench v1.1, abstraction_level="indep", target="qiskit"
 # ---------------------------------------------------------------------------
-_BASE_URL = "https://github.com/cda-tum/mqt-bench/tree/main/src/mqt/bench/benchmarks"
+_BASE_URL = "https://github.com/munich-quantum-toolkit/bench/tree/main/src/mqt/bench/benchmarks"
 
 _STATIC_TABLE: list[dict] = [
     # QAOA
@@ -206,12 +206,52 @@ _ALIASES: dict[str, str] = {
 
 
 def _mqt_bench_available() -> bool:
-    """Check if mqt.bench is installed."""
+    """Check if mqt.bench is installed and compatible with the installed Qiskit.
+
+    mqt-bench < 2.2.2 breaks on Qiskit 2.4 (see mqt-bench PR #895). When that
+    combination is detected, fall back to the static reference table.
+    """
     try:
         import mqt.bench  # noqa: F401
-        return True
     except ImportError:
         return False
+    try:
+        import importlib.metadata as _md
+
+        def _ver(s: str) -> tuple[int, ...]:
+            out: list[int] = []
+            for p in s.split("."):
+                digits = ""
+                for c in p:
+                    if c.isdigit():
+                        digits += c
+                    else:
+                        break
+                if not digits:
+                    break
+                out.append(int(digits))
+            return tuple(out)
+
+        bench_v = _ver(_md.version("mqt.bench"))
+        if bench_v and bench_v < (2, 2, 2):
+            try:
+                qiskit_v = _ver(_md.version("qiskit"))
+            except _md.PackageNotFoundError:
+                qiskit_v = ()
+            if qiskit_v >= (2, 4):
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "mqt.bench %s is incompatible with qiskit %s "
+                    "(need mqt.bench>=2.2.2 for Qiskit 2.4); "
+                    "falling back to static reference table.",
+                    ".".join(map(str, bench_v)),
+                    ".".join(map(str, qiskit_v)),
+                )
+                return False
+    except Exception:
+        pass
+    return True
 
 
 def find_references(

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -1,0 +1,720 @@
+//! Unified PyO3 surface for Arvak HAL backends.
+//!
+//! This module is the single bridge between Python callers and the native
+//! Rust adapter implementations of [`arvak_hal::Backend`]. It exposes:
+//!
+//! - [`PyBackend`] — wraps any `Arc<dyn Backend + Send + Sync>` and proxies
+//!   the HAL trait methods to Python via sync-over-async.
+//! - [`PyJobHandle`] — opaque handle returned from `submit()`, supports
+//!   `status()`, `result()`, `wait()`, `cancel()`.
+//! - [`PyCapabilities`], [`PyJobStatus`], [`PyExecutionResult`],
+//!   [`PyValidationResult`], [`PyAvailability`] — read-only Python views of
+//!   the corresponding HAL types.
+//! - Module-level functions `backend_for(name)` and `list_backends()`.
+//!
+//! # Design
+//!
+//! The HAL `Backend` trait is `#[async_trait]`. Python users expect
+//! synchronous blocking semantics (matching Qiskit `JobV1`). We satisfy
+//! that by running every async method on a process-wide tokio runtime and
+//! releasing the GIL during the `block_on` so Python threads can make
+//! progress.
+//!
+//! See `docs/RFC/0001-native-backend-unification.md` for the design rationale.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use pyo3::exceptions::{
+    PyConnectionError, PyPermissionError, PyRuntimeError, PyTimeoutError, PyValueError,
+};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+use arvak_hal::{
+    Backend, BackendAvailability, Capabilities, ExecutionResult, HalError, JobId, JobStatus,
+    ValidationResult,
+};
+
+// ---------------------------------------------------------------------------
+// Shared tokio runtime (sync-over-async)
+// ---------------------------------------------------------------------------
+
+static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+fn runtime() -> &'static tokio::runtime::Runtime {
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("arvak-python-bg")
+            .build()
+            .expect("failed to build tokio runtime for arvak-python")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping: HalError → Python exception
+// ---------------------------------------------------------------------------
+
+fn hal_to_py_err(e: HalError) -> PyErr {
+    let msg = e.to_string();
+    match e {
+        HalError::BackendUnavailable(_) => PyConnectionError::new_err(msg),
+        HalError::AuthenticationFailed(_) | HalError::Auth(_) => PyPermissionError::new_err(msg),
+        HalError::Timeout(_) => PyTimeoutError::new_err(msg),
+        HalError::InvalidCircuit(_) | HalError::CircuitTooLarge(_) | HalError::InvalidShots(_) => {
+            PyValueError::new_err(msg)
+        }
+        HalError::Unsupported(_) => pyo3::exceptions::PyNotImplementedError::new_err(msg),
+        _ => PyRuntimeError::new_err(msg),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyCapabilities — read-only view of arvak_hal::Capabilities
+// ---------------------------------------------------------------------------
+
+/// Backend capabilities (read-only view).
+#[pyclass(name = "Capabilities", module = "arvak", frozen)]
+#[derive(Clone)]
+pub struct PyCapabilities {
+    inner: Arc<Capabilities>,
+}
+
+#[pymethods]
+impl PyCapabilities {
+    /// Backend name (e.g. `"simulator"`, `"iqm_garnet"`).
+    #[getter]
+    fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Number of qubits.
+    #[getter]
+    fn num_qubits(&self) -> u32 {
+        self.inner.num_qubits
+    }
+
+    /// Native gate set (sorted, OpenQASM 3 naming).
+    #[getter]
+    fn basis_gates(&self) -> Vec<String> {
+        let g = &self.inner.gate_set;
+        let mut out: Vec<String> = g
+            .single_qubit
+            .iter()
+            .chain(g.two_qubit.iter())
+            .chain(g.three_qubit.iter())
+            .cloned()
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// `true` if this is a simulator/emulator.
+    #[getter]
+    fn is_simulator(&self) -> bool {
+        self.inner.is_simulator
+    }
+
+    /// Maximum number of shots per job.
+    #[getter]
+    fn max_shots(&self) -> u32 {
+        self.inner.max_shots
+    }
+
+    /// Maximum gate operations per circuit, or `None` if uncapped.
+    #[getter]
+    fn max_circuit_ops(&self) -> Option<u32> {
+        self.inner.max_circuit_ops
+    }
+
+    /// Coupling map as a list of `[a, b]` pairs, or `None` for all-to-all.
+    ///
+    /// Returns `None` when the topology is fully connected — matches the
+    /// Qiskit `BackendV2.coupling_map = None` convention. For all other
+    /// topologies the explicit edge list is returned.
+    #[getter]
+    fn coupling_map(&self) -> Option<Vec<(u32, u32)>> {
+        use arvak_hal::TopologyKind;
+        if matches!(self.inner.topology.kind, TopologyKind::FullyConnected) {
+            return None;
+        }
+        let edges: Vec<(u32, u32)> = self.inner.topology.edges.clone();
+        if edges.is_empty() { None } else { Some(edges) }
+    }
+
+    /// Capability feature flags (e.g. `"statevector"`, `"dynamic_circuits"`).
+    #[getter]
+    fn features(&self) -> Vec<String> {
+        self.inner.features.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<Capabilities(name='{}', qubits={}, simulator={})>",
+            self.inner.name, self.inner.num_qubits, self.inner.is_simulator
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyAvailability
+// ---------------------------------------------------------------------------
+
+/// Backend availability snapshot.
+#[pyclass(name = "Availability", module = "arvak", frozen)]
+#[derive(Clone)]
+pub struct PyAvailability {
+    #[pyo3(get)]
+    is_available: bool,
+    #[pyo3(get)]
+    queue_depth: Option<u32>,
+    #[pyo3(get)]
+    estimated_wait_s: Option<u64>,
+    #[pyo3(get)]
+    status_message: Option<String>,
+}
+
+impl From<BackendAvailability> for PyAvailability {
+    fn from(a: BackendAvailability) -> Self {
+        Self {
+            is_available: a.is_available,
+            queue_depth: a.queue_depth,
+            estimated_wait_s: a.estimated_wait.map(|d| d.as_secs()),
+            status_message: a.status_message,
+        }
+    }
+}
+
+#[pymethods]
+impl PyAvailability {
+    fn __bool__(&self) -> bool {
+        self.is_available
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<Availability(available={}, queue={:?}, msg={:?})>",
+            self.is_available, self.queue_depth, self.status_message
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyValidationResult
+// ---------------------------------------------------------------------------
+
+/// Result of circuit validation.
+///
+/// One of three states:
+/// - `Valid` — circuit can be submitted as-is.
+/// - `Invalid` — circuit violates backend constraints; `reasons` is non-empty.
+/// - `RequiresTranspilation` — circuit needs compilation first; `details`
+///   describes what.
+#[pyclass(name = "ValidationResult", module = "arvak", frozen)]
+#[derive(Clone)]
+pub struct PyValidationResult {
+    #[pyo3(get)]
+    valid: bool,
+    #[pyo3(get)]
+    requires_transpilation: bool,
+    #[pyo3(get)]
+    reasons: Vec<String>,
+    #[pyo3(get)]
+    details: Option<String>,
+}
+
+impl From<ValidationResult> for PyValidationResult {
+    fn from(v: ValidationResult) -> Self {
+        match v {
+            ValidationResult::Valid => Self {
+                valid: true,
+                requires_transpilation: false,
+                reasons: vec![],
+                details: None,
+            },
+            ValidationResult::Invalid { reasons } => Self {
+                valid: false,
+                requires_transpilation: false,
+                reasons,
+                details: None,
+            },
+            ValidationResult::RequiresTranspilation { details } => Self {
+                valid: false,
+                requires_transpilation: true,
+                reasons: vec![],
+                details: Some(details),
+            },
+        }
+    }
+}
+
+#[pymethods]
+impl PyValidationResult {
+    fn __bool__(&self) -> bool {
+        self.valid
+    }
+
+    fn __repr__(&self) -> String {
+        if self.valid {
+            "<ValidationResult(valid)>".into()
+        } else if self.requires_transpilation {
+            format!(
+                "<ValidationResult(requires_transpilation, details={:?})>",
+                self.details
+            )
+        } else {
+            format!("<ValidationResult(invalid, reasons={:?})>", self.reasons)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyJobStatus
+// ---------------------------------------------------------------------------
+
+/// Job status. String values: `"queued"`, `"running"`, `"completed"`,
+/// `"failed"`, `"cancelled"`.
+#[pyclass(name = "JobStatus", module = "arvak", frozen)]
+#[derive(Clone)]
+pub struct PyJobStatus {
+    #[pyo3(get)]
+    state: String,
+    #[pyo3(get)]
+    message: Option<String>,
+}
+
+impl From<JobStatus> for PyJobStatus {
+    fn from(s: JobStatus) -> Self {
+        match s {
+            JobStatus::Queued => Self {
+                state: "queued".into(),
+                message: None,
+            },
+            JobStatus::Running => Self {
+                state: "running".into(),
+                message: None,
+            },
+            JobStatus::Completed => Self {
+                state: "completed".into(),
+                message: None,
+            },
+            JobStatus::Failed(msg) => Self {
+                state: "failed".into(),
+                message: Some(msg),
+            },
+            JobStatus::Cancelled => Self {
+                state: "cancelled".into(),
+                message: None,
+            },
+        }
+    }
+}
+
+#[pymethods]
+impl PyJobStatus {
+    fn is_terminal(&self) -> bool {
+        matches!(self.state.as_str(), "completed" | "failed" | "cancelled")
+    }
+
+    fn is_done(&self) -> bool {
+        self.state == "completed"
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.message {
+            Some(m) => format!("<JobStatus({}: {})>", self.state, m),
+            None => format!("<JobStatus({})>", self.state),
+        }
+    }
+
+    fn __str__(&self) -> String {
+        self.state.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyExecutionResult
+// ---------------------------------------------------------------------------
+
+/// Result of circuit execution. Counts are accessed via `.counts` (a dict).
+#[pyclass(name = "ExecutionResult", module = "arvak", frozen)]
+#[derive(Clone)]
+pub struct PyExecutionResult {
+    inner: Arc<ExecutionResult>,
+}
+
+#[pymethods]
+impl PyExecutionResult {
+    /// Measurement counts as `{bitstring: count}`.
+    #[getter]
+    fn counts(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        for (bitstring, count) in self.inner.counts.iter() {
+            d.set_item(bitstring, count)?;
+        }
+        Ok(d.into())
+    }
+
+    /// Number of shots executed.
+    #[getter]
+    fn shots(&self) -> u32 {
+        self.inner.shots
+    }
+
+    /// Execution time in milliseconds, if reported by the backend.
+    #[getter]
+    fn execution_time_ms(&self) -> Option<u64> {
+        self.inner.execution_time_ms
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<ExecutionResult(shots={}, bitstrings={})>",
+            self.inner.shots,
+            self.inner.counts.len()
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyJobHandle
+// ---------------------------------------------------------------------------
+
+/// Handle to a submitted job.
+///
+/// Returned by [`PyBackend::submit`]. Holds a strong reference to the
+/// originating backend so the job survives the Python `backend` going out
+/// of scope between submission and result retrieval.
+#[pyclass(name = "JobHandle", module = "arvak")]
+pub struct PyJobHandle {
+    backend: Arc<dyn Backend + Send + Sync>,
+    job_id: JobId,
+    shots: u32,
+}
+
+#[pymethods]
+impl PyJobHandle {
+    /// Opaque job identifier.
+    #[getter]
+    fn job_id(&self) -> String {
+        self.job_id.0.clone()
+    }
+
+    /// Number of shots originally requested.
+    #[getter]
+    fn shots(&self) -> u32 {
+        self.shots
+    }
+
+    /// Query current status (single round-trip, not blocking until done).
+    fn status(&self, py: Python<'_>) -> PyResult<PyJobStatus> {
+        let backend = self.backend.clone();
+        let job_id = self.job_id.clone();
+        let s = py
+            .detach(move || runtime().block_on(async move { backend.status(&job_id).await }))
+            .map_err(hal_to_py_err)?;
+        Ok(s.into())
+    }
+
+    /// Cancel the job.
+    fn cancel(&self, py: Python<'_>) -> PyResult<()> {
+        let backend = self.backend.clone();
+        let job_id = self.job_id.clone();
+        py.detach(move || runtime().block_on(async move { backend.cancel(&job_id).await }))
+            .map_err(hal_to_py_err)
+    }
+
+    /// Block until the job completes, then return the result.
+    ///
+    /// Uses the HAL `wait()` default implementation (500 ms poll interval,
+    /// 5-minute timeout). For shot-only simulators this returns essentially
+    /// immediately.
+    fn result(&self, py: Python<'_>) -> PyResult<PyExecutionResult> {
+        let backend = self.backend.clone();
+        let job_id = self.job_id.clone();
+        let res = py
+            .detach(move || runtime().block_on(async move { backend.wait(&job_id).await }))
+            .map_err(hal_to_py_err)?;
+        Ok(PyExecutionResult {
+            inner: Arc::new(res),
+        })
+    }
+
+    /// Alias for [`Self::result`] (Qiskit `JobV1` compat).
+    fn wait(&self, py: Python<'_>) -> PyResult<PyExecutionResult> {
+        self.result(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<JobHandle(id={}, shots={})>", self.job_id.0, self.shots)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyBackend
+// ---------------------------------------------------------------------------
+
+/// Native Arvak backend handle.
+///
+/// Returned by [`backend_for`]. Wraps an `Arc<dyn arvak_hal::Backend>` and
+/// proxies HAL methods to Python via sync-over-async. One Python class
+/// handles every supported vendor — vendor-specific behaviour comes from
+/// `capabilities()` at the Rust side.
+#[pyclass(name = "Backend", module = "arvak")]
+pub struct PyBackend {
+    inner: Arc<dyn Backend + Send + Sync>,
+}
+
+#[pymethods]
+impl PyBackend {
+    /// Backend name (e.g. `"simulator"`, `"iqm_garnet"`).
+    #[getter]
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    /// Backend capabilities (cached at construction by the adapter).
+    fn capabilities(&self) -> PyCapabilities {
+        PyCapabilities {
+            inner: Arc::new(self.inner.capabilities().clone()),
+        }
+    }
+
+    /// Number of qubits (Qiskit-compat shortcut for `.capabilities().num_qubits`).
+    #[getter]
+    fn num_qubits(&self) -> u32 {
+        self.inner.capabilities().num_qubits
+    }
+
+    /// Native gate set (Qiskit-compat).
+    #[getter]
+    fn basis_gates(&self) -> Vec<String> {
+        self.capabilities().basis_gates()
+    }
+
+    /// Coupling map, or `None` for all-to-all.
+    #[getter]
+    fn coupling_map(&self) -> Option<Vec<(u32, u32)>> {
+        self.capabilities().coupling_map()
+    }
+
+    /// Query backend availability (single round-trip).
+    fn availability(&self, py: Python<'_>) -> PyResult<PyAvailability> {
+        let backend = self.inner.clone();
+        let a = py
+            .detach(move || runtime().block_on(async move { backend.availability().await }))
+            .map_err(hal_to_py_err)?;
+        Ok(a.into())
+    }
+
+    /// Validate a circuit (parsed from QASM3) against backend constraints.
+    fn validate(&self, qasm: &str, py: Python<'_>) -> PyResult<PyValidationResult> {
+        let circuit = arvak_qasm3::parse(qasm).map_err(crate::error::parse_to_py_err)?;
+        let backend = self.inner.clone();
+        let v = py
+            .detach(move || runtime().block_on(async move { backend.validate(&circuit).await }))
+            .map_err(hal_to_py_err)?;
+        Ok(v.into())
+    }
+
+    /// Submit a circuit (QASM3 string) for execution. Returns a job handle.
+    ///
+    /// `parameters` maps `input float[64]` parameter names to concrete
+    /// values; pass `None` (or omit) for non-parametric circuits.
+    #[pyo3(signature = (qasm, shots=1024, parameters=None))]
+    fn submit(
+        &self,
+        qasm: &str,
+        shots: u32,
+        parameters: Option<HashMap<String, f64>>,
+        py: Python<'_>,
+    ) -> PyResult<PyJobHandle> {
+        if shots == 0 {
+            return Err(PyValueError::new_err("shots must be > 0"));
+        }
+        let circuit = arvak_qasm3::parse(qasm).map_err(crate::error::parse_to_py_err)?;
+        let backend = self.inner.clone();
+        let job_id = py
+            .detach(move || {
+                runtime().block_on(async move {
+                    backend.submit(&circuit, shots, parameters.as_ref()).await
+                })
+            })
+            .map_err(hal_to_py_err)?;
+        Ok(PyJobHandle {
+            backend: self.inner.clone(),
+            job_id,
+            shots,
+        })
+    }
+
+    /// Submit + wait + fetch — convenience wrapper.
+    ///
+    /// Equivalent to `backend.submit(qasm, shots, parameters).result()`.
+    #[pyo3(signature = (qasm, shots=1024, parameters=None))]
+    fn run(
+        &self,
+        qasm: &str,
+        shots: u32,
+        parameters: Option<HashMap<String, f64>>,
+        py: Python<'_>,
+    ) -> PyResult<PyExecutionResult> {
+        let handle = self.submit(qasm, shots, parameters, py)?;
+        handle.result(py)
+    }
+
+    fn __repr__(&self) -> String {
+        let cap = self.inner.capabilities();
+        format!(
+            "<Backend(name='{}', qubits={}, simulator={})>",
+            cap.name, cap.num_qubits, cap.is_simulator
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backend registry — builds backends by name
+// ---------------------------------------------------------------------------
+
+/// Construct a backend by name. Phase 1 supports `"sim"` only.
+///
+/// Future phases will add IBM/IQM/Quantinuum/etc. behind feature flags.
+fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> {
+    match name {
+        "sim" | "arvak_simulator" | "simulator" => {
+            #[cfg(feature = "simulator")]
+            {
+                Ok(Arc::new(arvak_adapter_sim::SimulatorBackend::new()))
+            }
+            #[cfg(not(feature = "simulator"))]
+            {
+                Err(HalError::Configuration(
+                    "simulator adapter not compiled in (enable 'simulator' feature)".into(),
+                ))
+            }
+        }
+        other => Err(HalError::Configuration(format!(
+            "unknown backend: {other} (known: {})",
+            known_backends().join(", ")
+        ))),
+    }
+}
+
+/// List backend names known to this build.
+fn known_backends() -> Vec<String> {
+    let mut v: Vec<String> = Vec::new();
+    #[cfg(feature = "simulator")]
+    {
+        v.push("sim".into());
+    }
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Module-level functions
+// ---------------------------------------------------------------------------
+
+/// Construct a native backend by name.
+///
+/// # Example
+/// ```python
+/// import arvak
+/// backend = arvak.backend_for("sim")
+/// result = backend.run(qasm_str, shots=1024)
+/// print(result.counts)
+/// ```
+#[pyfunction]
+pub fn backend_for(name: &str) -> PyResult<PyBackend> {
+    let inner = make_backend(name).map_err(hal_to_py_err)?;
+    Ok(PyBackend { inner })
+}
+
+/// Return a list of backend names known to this build of `arvak`.
+#[pyfunction]
+pub fn list_backends(py: Python<'_>) -> PyResult<Py<PyList>> {
+    let names = known_backends();
+    let list = PyList::empty(py);
+    for n in names {
+        list.append(n)?;
+    }
+    Ok(list.into())
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyBackend>()?;
+    m.add_class::<PyJobHandle>()?;
+    m.add_class::<PyCapabilities>()?;
+    m.add_class::<PyAvailability>()?;
+    m.add_class::<PyValidationResult>()?;
+    m.add_class::<PyJobStatus>()?;
+    m.add_class::<PyExecutionResult>()?;
+    m.add_function(wrap_pyfunction!(backend_for, m)?)?;
+    m.add_function(wrap_pyfunction!(list_backends, m)?)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "simulator")]
+    fn known_backends_lists_sim() {
+        let names = known_backends();
+        assert!(names.iter().any(|n| n == "sim"));
+    }
+
+    #[test]
+    #[cfg(feature = "simulator")]
+    fn make_backend_sim_succeeds() {
+        let b = match make_backend("sim") {
+            Ok(b) => b,
+            Err(e) => panic!("sim backend should build: {e}"),
+        };
+        assert!(b.capabilities().is_simulator);
+    }
+
+    #[test]
+    fn make_backend_unknown_fails() {
+        match make_backend("nope-not-a-backend") {
+            Ok(_) => panic!("expected unknown backend to fail"),
+            Err(e) => assert!(e.to_string().contains("unknown backend")),
+        }
+    }
+
+    #[test]
+    fn job_status_terminal_classification() {
+        assert!(!PyJobStatus::from(JobStatus::Queued).is_terminal());
+        assert!(!PyJobStatus::from(JobStatus::Running).is_terminal());
+        assert!(PyJobStatus::from(JobStatus::Completed).is_terminal());
+        assert!(PyJobStatus::from(JobStatus::Failed("x".into())).is_terminal());
+        assert!(PyJobStatus::from(JobStatus::Cancelled).is_terminal());
+    }
+
+    #[test]
+    fn validation_result_invalid_carries_reasons() {
+        let v: PyValidationResult = ValidationResult::Invalid {
+            reasons: vec!["too many qubits".into()],
+        }
+        .into();
+        assert!(!v.valid);
+        assert!(!v.requires_transpilation);
+        assert_eq!(v.reasons.len(), 1);
+    }
+
+    #[test]
+    fn availability_unavailable_message_preserved() {
+        let a: PyAvailability = BackendAvailability::unavailable("maintenance").into();
+        assert!(!a.is_available);
+        assert_eq!(a.status_message.as_deref(), Some("maintenance"));
+    }
+}

--- a/crates/arvak-python/src/lib.rs
+++ b/crates/arvak-python/src/lib.rs
@@ -20,6 +20,7 @@
 //! qc2 = arvak.from_qasm(qasm)
 //! ```
 
+mod backend;
 mod circuit;
 mod compile;
 mod error;
@@ -66,6 +67,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Projection simulator
     projection::register(m)?;
+
+    // Native backend bridge (HAL Backend trait via PyO3)
+    backend::register(m)?;
 
     Ok(())
 }

--- a/docs/RFC/0001-native-backend-unification.md
+++ b/docs/RFC/0001-native-backend-unification.md
@@ -1,0 +1,619 @@
+# RFC 0001 — Native Backend Unification
+
+| | |
+|---|---|
+| **Status** | Accepted (2026-05-23) |
+| **Author** | Daniel Hinderink |
+| **Created** | 2026-05-23 |
+| **Branch target** | unify-native-backends |
+| **Affects** | `arvak-python`, `arvak-hal`, all `arvak-adapter-*` crates |
+
+## Decisions on open questions (settled 2026-05-23)
+
+1. **Single class for all backends.** `ArvakBackend` only — capabilities come from `capabilities()` at the Rust side, not hardcoded per vendor.
+2. **No job persistence across processes for v1.** Helper API can be added if anyone asks.
+3. **All 12 adapters compiled into the default wheel.** `pip install arvak` works without extras for every supported backend.
+
+## Pending decisions (BLOCKING Phase 2)
+
+Surfaced during the Phase-1 implementation audit on 2026-05-27. See
+**Phase 1.5** below for full rationale and concrete options.
+
+- **A1.** How does `PyJobHandle.result()` handle jobs longer than the
+  current HAL `wait()` 5-minute timeout? *Recommendation: PyO3-level
+  polling loop with optional `timeout=None` argument.*
+- **A2.** Does `ArvakBackend.run()` block until results are in (current
+  Phase-1 behaviour, fine for sim, breaks for cloud), or return a
+  deferred handle (Qiskit `JobV1` semantics, mandatory for cloud)?
+  *Recommendation: deferred, with `ArvakJob` wrapping a list of
+  `PyJobHandle`s for multi-circuit batches.*
+
+Both fixes land inside Phase 2 as the first commits, before the IQM
+adapter is wired in.
+
+## Summary
+
+Replace the six vendor-specific Python backend classes in
+`arvak.integrations.qiskit.backend` (~3,000 lines of code, six vendor
+SDK dependencies) with a single `ArvakBackend` Python class that
+delegates to the native Rust `Backend` trait implementations via PyO3.
+This makes the architectural claim "Arvak is the Rust quantum OS, Python
+is a thin façade" actually true, instead of partially true.
+
+## Motivation
+
+### Current state
+
+Arvak has 12 native Rust backend adapters (`adapters/arvak-adapter-*`)
+implementing `arvak_hal::Backend`. The CLI and gRPC paths use them
+directly. **The Python `ArvakProvider` does not.** Instead, six parallel
+Python classes re-implement vendor submission, polling, and result
+parsing on top of vendor SDKs:
+
+| Python class | File:line | Lines | Uses (Python SDK) | Native Rust adapter exists? |
+|---|---|---|---|---|
+| `ArvakSimulatorBackend` | `backend.py:388` | ~80 | (none — runs `arvak.run_sim` via PyO3) | `arvak-adapter-sim` |
+| `ArvakIBMBackend` | `backend.py:465` | ~370 | `requests` against IBM Cloud REST | `arvak-adapter-ibm` |
+| `ArvakIQMResonanceBackend` | `backend.py:1273` | ~230 | `iqm-client[qiskit]==33.0.3` | `arvak-adapter-iqm` |
+| `ArvakScalewayBackend` | `backend.py:989` | ~280 | Scaleway QaaS HTTP | `arvak-adapter-scaleway` |
+| `ArvakQuantinuumBackend` | `backend.py:1733` | ~270 | Quantinuum REST | `arvak-adapter-quantinuum` |
+| `ArvakAQTBackend` | `backend.py:2422` | ~300 | AQT Arnica HTTP | `arvak-adapter-aqt` |
+| `ArvakIonQBackend` | `backend.py:2814` | ~370 | IonQ Cloud REST | `arvak-adapter-ionq` |
+
+The only Python class that *does* use the native Rust path is
+`ArvakSimulatorBackend`, and even it goes through `arvak.run_sim` (a
+`#[pyfunction]`) rather than through `arvak-adapter-sim` as a `Backend`
+trait impl.
+
+Concretely: today, calling `provider.get_backend('iqm_garnet').run(qc)`
+imports `iqm-client[qiskit]==33.0.3`, transpiles via `qiskit-on-iqm`,
+and submits through the IQM SDK — even though
+`adapters/arvak-adapter-iqm/src/api.rs` already implements the IQM
+Resonance REST API in 435 lines of `reqwest` against the same endpoint.
+
+### Why this is wrong
+
+1. **Two sources of truth per vendor.** Bug fixes, retry logic, error
+   taxonomy, validation rules, HAL contract debt (DEBT-01, DEBT-05,
+   DEBT-15) live in both places and drift.
+2. **The Python path bypasses Arvak's value proposition.** Users who
+   import `arvak` for "compile + route + submit through the Rust quantum
+   OS" get, for IQM, *Qiskit + iqm-client + arvak-compiler-as-helper*
+   instead.
+3. **Dependency surface.** `pyproject.toml` extras pull
+   `iqm-client[qiskit]`, `qiskit-ibm-runtime`, `pytket-quantinuum`,
+   `aqt-arnica`, etc. — each pinned to a specific version range that
+   constrains user environments.
+4. **Adding a new vendor doubles the work.** Today every vendor needs a
+   Rust adapter *and* a Python class. The architecture invites this.
+
+### Why now
+
+- Qiskit 2.4 migration just hit one of these vendor SDKs (`mqt-bench`
+  needed PR #895 for Qiskit 2.4 compat — same pattern will hit every
+  vendor SDK we bind to).
+- The HAL contract v2 cleanup (DEBT-01 through DEBT-25) just landed.
+  The Rust `Backend` trait is now stable enough to be the canonical
+  surface.
+- 12 native adapters exist and pass their tests. The Rust side is ready.
+
+## Goals
+
+1. One implementation per vendor, in Rust, exposed to Python through
+   PyO3.
+2. Single Python class — `arvak.ArvakBackend` — works for any backend
+   the Rust side knows about.
+3. Provider discovery driven by a Rust `BackendRegistry`, not by
+   hard-coded sets in Python.
+4. Remove vendor SDK dependencies from `arvak-python/pyproject.toml`
+   extras.
+5. Backward-compatible during migration: existing
+   `provider.get_backend('iqm_garnet').run(qc)` keeps working while
+   the implementation underneath swaps.
+
+## Non-goals
+
+- **Killing the `ArvakProvider` Qiskit-compat surface.** Users who write
+  Qiskit-style `provider.get_backend(...).run(circuit)` should keep
+  working forever. Only the *implementation* changes.
+- **Adding new vendor support.** This RFC is consolidation, not
+  expansion.
+- **Touching the compiler pipeline.** `arvak.compile`,
+  `BasisGates.iqm()`, `CouplingMap.*` are unchanged.
+- **Replacing the QASM3 ingress format.** Python passes QASM3 strings to
+  Rust; the Rust adapter takes `arvak_ir::Circuit`. Conversion happens
+  once at the boundary.
+
+## Proposed architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Python                                                          │
+│  arvak.integrations.qiskit                                       │
+│    ArvakProvider                                                 │
+│      .get_backend(name) → ArvakBackend                           │
+│                                                                  │
+│    ArvakBackend  (Qiskit-compat duck-typed class)                │
+│      .name, .num_qubits, .basis_gates, .coupling_map             │
+│      .run(qc, shots) → ArvakJob                                  │
+│      .availability(), .validate(), .submit(), .status(), ...     │
+│                                                                  │
+│    ArvakJob                                                      │
+│      .job_id(), .status(), .result()                             │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ PyO3
+┌────────────────────────────▼─────────────────────────────────────┐
+│  arvak-python (Rust, PyO3)                                       │
+│    #[pyclass] PyBackend     ← wraps Box<dyn arvak_hal::Backend>  │
+│    #[pyclass] PyJobHandle   ← wraps (backend_ref, JobId)         │
+│    #[pyclass] PyCapabilities, PyJobStatus, PyExecutionResult     │
+│    #[pyfunction] backend_for(name: &str) -> PyBackend            │
+│    #[pyfunction] list_backends() -> Vec<String>                  │
+│                                                                  │
+│    BackendRegistry — single-process registry, lazy construction  │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ Rust trait dispatch
+┌────────────────────────────▼─────────────────────────────────────┐
+│  arvak-hal::Backend                                              │
+│    name, capabilities, availability, validate,                   │
+│    submit, status, result, cancel, wait                          │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ implements
+       ┌─────────────────────┼─────────────────────┐
+       ▼                     ▼                     ▼
+  adapter-ibm          adapter-iqm            adapter-quantinuum  ... (12 total)
+```
+
+### PyO3 surface
+
+A single `PyBackend` wraps `Box<dyn arvak_hal::Backend + Send + Sync>`.
+Methods mirror the trait, with these translations:
+
+| HAL trait method | Python method | Returns |
+|---|---|---|
+| `name()` | `.name` (property) | `str` |
+| `capabilities()` | `.capabilities()` | `PyCapabilities` |
+| `availability().await` | `.availability()` | `PyAvailability` |
+| `validate(c).await` | `.validate(qasm)` | `PyValidationResult` |
+| `submit(c, shots, params).await` | `.submit(qasm, shots, params)` | `PyJobHandle` |
+| `status(id).await` | `.status(job_id)` | `PyJobStatus` (enum) |
+| `result(id).await` | `.result(job_id)` | `PyExecutionResult` |
+| `cancel(id).await` | `.cancel(job_id)` | `None` |
+| `wait(id).await` | `.wait(job_id, timeout=300)` | `PyExecutionResult` |
+
+`PyJobHandle` holds a strong reference to its `PyBackend` so the
+Python-side job survives the backend going out of scope between
+`submit()` and `result()`.
+
+### Async strategy
+
+The HAL `Backend` trait is `async_trait`. Python callers expect
+synchronous blocking semantics from `backend.run(qc).result()`
+(matching Qiskit's `JobV1`). Two options:
+
+1. **Sync-over-async** (recommended): each `#[pymethod]` blocks on the
+   tokio runtime via `pyo3_async_runtimes::tokio::get_runtime().block_on(...)`.
+   The runtime is created once at module init. Python users see
+   ordinary blocking methods.
+2. **Native async coroutines**: methods return Python `awaitable`s via
+   `pyo3-async-runtimes`. Lets advanced users do `await
+   backend.submit(...)`. Strictly more flexible but breaks the Qiskit
+   `JobV1` compat contract.
+
+**Recommendation: Option 1 for v1**, with the door open to add an
+`asyncio_*` variant later if anyone asks. Rationale: every existing
+caller in our codebase (and every Qiskit user) is sync. We can add
+async without breaking sync; we can't easily go the other way.
+
+The tokio runtime is shared with every other PyO3 entry point — we
+already have one for `arvak.run_sim`. The `pyo3-async-runtimes` crate
+handles GIL release during `block_on` correctly.
+
+### Backend registry
+
+Each adapter crate has a Cargo feature in `arvak-python`:
+
+```toml
+# crates/arvak-python/Cargo.toml
+[features]
+default       = ["adapter-sim"]
+adapter-sim   = ["arvak-adapter-sim"]
+adapter-ibm   = ["arvak-adapter-ibm"]
+adapter-iqm   = ["arvak-adapter-iqm"]
+adapter-aqt   = ["arvak-adapter-aqt"]
+adapter-ionq  = ["arvak-adapter-ionq"]
+adapter-quantinuum = ["arvak-adapter-quantinuum"]
+adapter-scaleway   = ["arvak-adapter-scaleway"]
+adapter-braket     = ["arvak-adapter-braket"]
+adapter-quandela   = ["arvak-adapter-quandela"]
+adapter-ddsim      = ["arvak-adapter-ddsim"]
+adapter-cudaq      = ["arvak-adapter-cudaq"]
+all-adapters       = ["adapter-sim", "adapter-ibm", "adapter-iqm", ...]
+```
+
+`BackendRegistry::get(name)` matches on the prefix:
+
+```rust
+match name {
+    "sim" => Ok(Box::new(SimBackend::new()?)),
+    n if n.starts_with("ibm_")        => Ok(Box::new(IbmBackend::from_env(n)?)),
+    n if n.starts_with("iqm_")        => Ok(Box::new(IqmBackend::from_env(n)?)),
+    n if n.starts_with("quantinuum_") => Ok(Box::new(QuantinuumBackend::from_env(n)?)),
+    n if n.starts_with("aqt_")        => Ok(Box::new(AqtBackend::from_env(n)?)),
+    n if n.starts_with("ionq_")       => Ok(Box::new(IonQBackend::from_env(n)?)),
+    n if n.starts_with("scaleway_")   => Ok(Box::new(ScalewayBackend::from_env(n)?)),
+    _ => Err(HalError::UnknownBackend(name.into())),
+}
+```
+
+Each branch is `#[cfg(feature = "adapter-X")]`. Default wheel ships
+with `adapter-sim` only; `pip install arvak[hardware]` pulls in all
+adapters via the `all-adapters` cargo feature.
+
+### Circuit ingress
+
+The HAL `submit()` takes `&arvak_ir::Circuit`. PyO3 receives a QASM3
+string (the existing pattern from `qiskit_to_arvak`) and converts:
+
+```rust
+#[pymethods]
+impl PyBackend {
+    fn submit(&self, qasm: &str, shots: u32, parameters: Option<HashMap<String, f64>>) -> PyResult<PyJobHandle> {
+        let circuit = arvak_ir::from_qasm(qasm)?;
+        let rt = pyo3_async_runtimes::tokio::get_runtime();
+        let job_id = rt.block_on(self.inner.submit(&circuit, shots, parameters.as_ref()))?;
+        Ok(PyJobHandle { backend: self.clone_arc(), job_id })
+    }
+}
+```
+
+This preserves the QASM3-as-interchange invariant we already document
+in `docs/hal-contract.md`.
+
+### Error mapping
+
+Map `arvak_hal::HalError` variants to the existing Python exception
+hierarchy:
+
+| HalError variant | Python exception |
+|---|---|
+| `Validation(_)` | `ArvakValidationError` |
+| `BackendUnavailable(_)` | `ArvakBackendUnavailableError` |
+| `Authentication(_)` | `ArvakAuthenticationError` |
+| `Submission(_)` | `ArvakSubmissionError` |
+| `JobFailed(_)` | `ArvakJobError` |
+| `JobCancelled` | `ArvakJobCancelledError` |
+| `Timeout(_)` | `ArvakTimeoutError` |
+| `Unsupported(_)` | `NotImplementedError` |
+| everything else | `ArvakError` |
+
+The exception classes already exist (`backend.py:24–53`) and stay.
+
+## Migration plan
+
+### Phase 0 (this RFC)
+
+Decision document. No code. Output: this file, reviewed and `Status:
+Accepted`.
+
+### Phase 1 — Pilot: native simulator (1–2 days)
+
+1. Add `PyBackend`, `PyJobHandle`, `PyCapabilities`,
+   `PyExecutionResult`, `PyValidationResult`, `PyJobStatus`,
+   `PyAvailability` in `crates/arvak-python/src/backend.rs`.
+2. Wire `arvak-adapter-sim` as a default-feature dep.
+3. Add `backend_for(name)` and `list_backends()` `#[pyfunction]`s.
+4. Add `ArvakBackend` Python class in
+   `crates/arvak-python/python/arvak/integrations/qiskit/backend.py`
+   delegating to the new PyO3 surface.
+5. Make `provider.get_backend('sim')` return the new class instead of
+   `ArvakSimulatorBackend`. Mark the old class deprecated but keep it
+   importable.
+6. Test parity: existing test suite for `ArvakSimulatorBackend` must
+   pass against the new implementation.
+
+**Validates:** PyO3 async runtime, type bindings, error mapping. No
+external service. Reversible by reverting one PR.
+
+**Status: Done (2026-05-23).** 15/15 Phase-1 smoke tests pass plus the
+five follow-up tests (B1/C1/E1/E2). Implementation audit on
+2026-05-27 surfaced two cloud-vendor design questions (A1, A2 below)
+that MUST be decided before Phase 2 begins.
+
+### Phase 1.5 — Cloud-vendor design questions (BLOCKING for Phase 2)
+
+The Phase 1 sim pilot validated the basic PyO3 bridge end-to-end, but
+sim returns results instantly. Two assumptions that hold for sim
+**break the moment a cloud backend with a real queue is wired in**.
+Both need an explicit decision before `arvak-adapter-iqm` is wired in
+Phase 2; otherwise we encode a wrong default that's expensive to undo
+once every vendor copies the same pattern.
+
+#### A1 — `wait()` 5-minute timeout
+
+**Current state:** `PyJobHandle.result()` delegates to
+`arvak_hal::Backend::wait()`, which has a default implementation that
+polls every 500 ms for a maximum of 5 minutes
+(`crates/arvak-hal/src/backend.rs:186–207`). After 5 minutes it
+returns `HalError::Timeout`, which the PyO3 layer surfaces as
+`PyTimeoutError`.
+
+**Problem:** Real IBM/IQM/Quantinuum/IonQ jobs routinely sit in the
+queue longer than 5 minutes. A Qiskit user who calls
+`job.result()` and expects "block until done" gets an exception
+instead — and not even a useful one, because the job is still running
+fine on the backend.
+
+**Options:**
+
+1. **`PyJobHandle.result(timeout=None)` with its own polling loop.**
+   When `timeout is None`, block forever (or until a sentinel exit
+   condition). When `timeout` is set, honour it. Polling lives in the
+   PyO3 wrapper, calling `backend.status()` + `backend.result()` rather
+   than `backend.wait()`. Backwards-compat: keep the 5-min HAL
+   `wait()` default for direct Rust callers.
+2. **Per-backend `wait()` override in each adapter.** Each cloud
+   adapter implements `wait()` with backend-appropriate polling
+   (e.g. IQM job statuses already expose `estimated_completion_time`).
+   No timeout by default; users can break out with `Ctrl-C` or close
+   the Python process. Less code in the PyO3 layer, more code in
+   N adapters.
+3. **Both.** PyO3 layer accepts `timeout`, adapters provide
+   intelligent polling cadence. Strictly more capable, more surface.
+
+**Recommendation: Option 1 for Phase 2**, with the door open to add
+Option 2's per-adapter polling cadence in Phase 3+. Rationale: one
+change-site, immediately fixes the timeout problem for every vendor,
+doesn't block Phase 2 on cleaning up HAL `wait()`. The PyO3-level
+polling loop is ~20 lines.
+
+**Sketch:**
+
+```rust
+#[pymethods]
+impl PyJobHandle {
+    #[pyo3(signature = (timeout=None, poll_interval_ms=500))]
+    fn result(
+        &self,
+        timeout: Option<f64>,
+        poll_interval_ms: u64,
+        py: Python<'_>,
+    ) -> PyResult<PyExecutionResult> {
+        let backend = self.backend.clone();
+        let job_id = self.job_id.clone();
+        let deadline = timeout.map(|s| std::time::Instant::now() + Duration::from_secs_f64(s));
+        let poll = Duration::from_millis(poll_interval_ms);
+        py.detach(move || runtime().block_on(async move {
+            loop {
+                match backend.status(&job_id).await? {
+                    JobStatus::Completed => return backend.result(&job_id).await,
+                    JobStatus::Failed(m) => return Err(HalError::JobFailed(m)),
+                    JobStatus::Cancelled => return Err(HalError::JobCancelled),
+                    JobStatus::Queued | JobStatus::Running => {
+                        if let Some(d) = deadline {
+                            if std::time::Instant::now() >= d {
+                                return Err(HalError::Timeout(job_id.0.clone()));
+                            }
+                        }
+                        tokio::time::sleep(poll).await;
+                    }
+                }
+            }
+        })).map_err(hal_to_py_err).map(|r| PyExecutionResult { inner: Arc::new(r) })
+    }
+}
+```
+
+#### A2 — `ArvakBackend.run()` is eager-blocking, not deferred
+
+**Current state:** `ArvakBackend.run(circuits, shots)` calls
+`self._native.run(qasm, shots, parameters)` for each circuit, which
+internally chains `submit() -> wait() -> result()`. By the time
+`backend.run()` returns, the work is done. The returned `ArvakJob`
+just wraps already-computed counts; `.result()` is instant,
+`.status()` always says `"DONE"`.
+
+**Problem:** Qiskit `JobV1` semantics — and every existing Qiskit
+caller — assume `backend.run(qc)` returns **immediately** with a
+handle, and `job.result()` is what blocks. With cloud backends this
+matters operationally:
+
+- Users want to fire multiple `backend.run()` calls in parallel and
+  collect results later.
+- Notebooks want `job = backend.run(qc); do_other_work(); counts = job.result()`.
+- Cancel semantics only make sense if `run()` returns before the job
+  finishes.
+
+For sim this distinction is invisible (results are instant either
+way). For IQM/IBM/Quantinuum the eager pattern means
+`backend.run(qc)` blocks the calling thread for the full queue +
+execution time.
+
+**Options:**
+
+1. **Restructure `ArvakBackend.run()` to be deferred.** Returns
+   immediately with a thin `ArvakJob` that holds a `PyJobHandle` list
+   (one per circuit). `.result()` calls `handle.result()` for each
+   and aggregates. Native multi-circuit batch APIs (IBM Sampler,
+   Quantinuum batch) become a separate concern.
+2. **Add a `defer=True` flag to `run()`.** Eager by default, deferred
+   on opt-in. Worst of both — users have to know about the flag,
+   batch behaviour is still ad-hoc.
+3. **Native per-circuit `submit()` + a `BatchJob` wrapper.** Submit
+   all circuits as separate HAL jobs, return a wrapper that waits on
+   all of them. Closest to Qiskit `JobV1` for many-circuit batches,
+   no special batch API needed yet.
+
+**Recommendation: Option 1 for Phase 2**, with Option 3's
+multi-handle aggregation built in from the start because it's the
+natural shape. Concretely:
+
+```python
+class ArvakBackend:
+    def run(self, circuits, shots: int = 1024, **options) -> 'ArvakJob':
+        if not isinstance(circuits, list):
+            circuits = [circuits]
+        parameters = options.get('parameters')
+        # Submit all circuits; collect handles. Does NOT block.
+        handles = [
+            self._native.submit(_qiskit_to_qasm3(qc), shots, parameters)
+            for qc in circuits
+        ]
+        return ArvakJob(backend=self, handles=handles, shots=shots)
+
+class ArvakJob:
+    """Real deferred job — wraps one or more PyJobHandle instances."""
+    def __init__(self, backend, handles, shots):
+        self._backend = backend
+        self._handles = handles
+        self._shots = shots
+        self._cached: list[dict] | None = None
+
+    def result(self, timeout: float | None = None) -> 'ArvakResult':
+        if self._cached is None:
+            self._cached = [
+                dict(h.result(timeout=timeout).counts) for h in self._handles
+            ]
+        return ArvakResult(self._backend.name, self._cached, self._shots)
+
+    def status(self) -> str:
+        states = [h.status().state for h in self._handles]
+        if all(s == "completed" for s in states): return "DONE"
+        if any(s == "failed" for s in states):    return "ERROR"
+        if any(s == "cancelled" for s in states): return "CANCELLED"
+        if any(s == "running" for s in states):   return "RUNNING"
+        return "QUEUED"
+
+    def cancel(self) -> None:
+        for h in self._handles: h.cancel()
+```
+
+**Consequence for Phase 1:** the current sim path keeps working
+unchanged (sim returns instantly, so eager vs deferred is invisible).
+The restructure ships as part of Phase 2.
+
+#### A1 + A2 — what they cost
+
+| Item | Files touched | LOC | Risk |
+|---|---|---|---|
+| A1 (timeout on `result`) | `backend.rs` (one method) | ~25 | low — pure addition |
+| A2 (deferred `run`) | `backend.py` (`ArvakBackend.run`, `ArvakJob`) | ~40 | low — sim behaviour identical |
+
+Together: roughly half a day. They land **inside Phase 2** as the
+first commits before the IQM adapter is wired in, so the IQM
+integration immediately benefits from the right semantics.
+
+#### Decision needed before Phase 2 begins
+
+- [ ] A1: confirm Option 1 (PyO3-level polling with optional timeout)
+  or pick another.
+- [ ] A2: confirm Option 1+3 hybrid (deferred multi-handle) or pick
+  another.
+
+### Phase 2 — IQM Resonance (1–2 days)
+
+The vendor we just discussed. Validates the cloud-vendor pattern.
+
+1. Wire `arvak-adapter-iqm` as an optional feature.
+2. Add IQM branch to `BackendRegistry::get`.
+3. Switch `provider.get_backend('iqm_*')` to return `ArvakBackend`.
+4. Remove `iqm-client[qiskit]==33.0.3` from `pyproject.toml` extras.
+5. Mark `ArvakIQMResonanceBackend` deprecated.
+
+**Validates:** cloud auth via env (`IQM_TOKEN`), OIDC path for LUMI/LRZ
+still works (existing native adapter supports it), submission/polling
+through PyO3.
+
+### Phases 3–6 — Remaining vendors (1–2 days each)
+
+In order of likely difficulty / blast radius:
+3. Scaleway (similar shape to IQM)
+4. IBM (most users — extra care, more parametrized circuits)
+5. Quantinuum (batch API quirks)
+6. AQT, IonQ (smaller surface)
+
+Each phase: native adapter wired + Python class switched + vendor SDK
+dependency removed + old class deprecated.
+
+### Phase 7 — Cleanup (0.5 day)
+
+1. Delete deprecated `ArvakSimulatorBackend`,
+   `ArvakIBMBackend`, `ArvakIQMResonanceBackend`, etc.
+2. Delete now-orphan `ArvakIBMJob`, `ArvakIQMResonanceJob`, etc.
+3. Drop vendor SDK extras from `pyproject.toml`.
+4. CHANGELOG entry, major version bump (this is a breaking change for
+   anyone who imported the per-vendor classes directly).
+
+## Backwards compatibility
+
+- `provider.get_backend('iqm_garnet').run(qc, shots).result().get_counts()`
+  keeps working throughout — that's the surface 99% of users touch.
+- Direct imports of `ArvakIBMBackend` etc. emit a `DeprecationWarning`
+  from Phase 1 onward and break at Phase 7. Documented in CHANGELOG.
+- Job IDs change format (HAL uses opaque UUIDs; some vendor classes
+  exposed vendor-native IDs). If anyone has persisted job IDs across
+  sessions, they break. This affects no known caller — verify before
+  Phase 7.
+- The PyO3 module gets larger by the size of compiled adapters (small —
+  most adapter code is `reqwest` calls). Wheel grows ~2–3 MB.
+
+## Risks & open questions
+
+### Risks
+
+1. **Vendor API drift during migration.** If IBM changes its REST
+   contract while we're porting Quantinuum, the IBM native adapter
+   needs an out-of-band fix. Mitigation: the native adapters already
+   exist and are tested — Phase N only switches the *call site*, not
+   the implementation.
+2. **Hidden Python-side features in the old classes.** Some Python
+   classes do small things the Rust adapter doesn't (e.g.,
+   `ArvakIBMBackend` has a 27-qubit topology hardcoded as fallback).
+   Audit each Python class for behaviour the Rust adapter is missing
+   *before* deletion, not after.
+3. **Async runtime sharing.** If `arvak-python` ever needs a different
+   tokio runtime config than what `pyo3-async-runtimes` defaults to
+   (e.g., specific worker thread counts), we need to set that up at
+   module init. Not a blocker, just a note.
+4. **gRPC service compatibility.** `arvak-grpc` already uses these
+   native adapters — no change needed. But if Phase N changes the HAL
+   `Backend` trait shape (it shouldn't), gRPC needs to follow.
+
+### Open questions
+
+1. **Should `ArvakBackend` be the same class for all backends, or a
+   thin Qiskit-compat subclass per vendor?** Going with single class +
+   prefix-dispatch in this RFC. If users complain about `.basis_gates`
+   needing to look different per vendor, revisit — but a single class
+   that asks Rust for `capabilities().native_gates()` is cleaner.
+2. **Job persistence across processes.** Current vendor classes store
+   nothing between sessions. Native adapters return `JobId(String)`
+   which IS persistable across processes via `backend.status(JobId)`.
+   Worth exposing a `provider.attach_job(backend_name, job_id)` helper?
+   Out of scope for v1.
+3. **Adapter feature defaults.** Ship `arvak` with all adapters
+   compiled in by default (bigger wheel, no-friction), or with `sim`
+   only (small wheel, `pip install arvak[hardware]` for the rest)?
+   Recommendation: ship all by default — the size delta is modest and
+   `pip install arvak` should "just work" for new users.
+4. **What about `arvak.integrations.cirq`, `pennylane`, `qrisp`?** Same
+   pattern applies — their backend objects also currently exist as
+   Python classes. This RFC scopes to the Qiskit integration. Once
+   Qiskit is done, the pattern ports trivially. Out of scope here.
+
+## Acceptance criteria for marking this RFC accepted
+
+- [ ] Daniel reads it, marks `Status: Accepted` (or returns with
+  changes).
+- [ ] Phase 1 sub-tasks have rough size estimates.
+- [ ] Open question 3 (default features) decided.
+
+## Acceptance criteria for closing each phase
+
+- [ ] All existing tests for that vendor pass against the new
+  implementation.
+- [ ] At least one happy-path E2E test against the real backend (or a
+  high-fidelity stub for vendors we can't burn credentials on).
+- [ ] Vendor SDK dependency removed from `pyproject.toml`.
+- [ ] CHANGELOG entry under `### Changed`.
+- [ ] Old Python class emits `DeprecationWarning` (until Phase 7).


### PR DESCRIPTION
Three logically separable commits in one PR for review velocity. Each
commit stands on its own and can be reverted independently if needed.

## Commits

### 1. `ci: bump GH actions to Node-24-compatible majors`
GitHub forces Node.js 20 → 24 on 2026-06-16 (tomorrow). Every recent CI
run emits deprecation warnings. Bumps:
- `actions/checkout@v4` → v5
- `actions/cache@v4` → v5
- `actions/setup-python@v5` → v6
- `actions/upload-artifact@v4` → v5
- `actions/download-artifact@v4` → v5

Third-party actions (PyO3/maturin-action, dtolnay/rust-toolchain,
docker/setup-buildx-action, softprops/action-gh-release) untouched —
not flagged by GitHub's deprecation notice.

### 2. `chore(python): bump Qiskit baseline to 2.x, update MQT references`
Verified our integration code against Qiskit 2.4.0 (currently 2.4.0+
on PyPI). Lower bound was stale at 1.0.0 in several places. Bumps and
matching housekeeping for the MQT-Bench / Qiskit-2.4 compat issue
(mqt-bench < 2.2.2 breaks on Qiskit 2.4 per mqt-bench PR #895). Adds
a runtime guard in `_mqt_bench_available()` that falls back to the
static reference table with a logged warning when that combination is
detected.

### 3. `feat(python): RFC-0001 Phase 1 — native HAL backend bridge`
The big one. Adds a single PyO3 surface that wraps any
`arvak_hal::Backend` impl and exposes it through one `ArvakBackend`
Python class. Replaces `ArvakSimulatorBackend` as the path for
`provider.get_backend('sim')`. Old class kept importable with a
`DeprecationWarning`.

See `docs/RFC/0001-native-backend-unification.md` for the full
rationale, the migration plan (Phase 2: IQM, Phase 3–7: remaining
vendors), and the two cloud-vendor design questions (A1: wait()
timeout, A2: deferred vs eager run()) that need to be answered before
Phase 2 begins.

**The point:** `ArvakProvider().get_backend('iqm_garnet').run(qc)`
currently routes through `iqm-client[qiskit]==33.0.3` instead of the
existing native `arvak-adapter-iqm` Rust adapter. Same shape for IBM,
Quantinuum, AQT, IonQ, Scaleway. Phase 1 lands the bridge; subsequent
phases switch each vendor over and drop the vendor SDK extras.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo check -p arvak-python` green
- [x] 6/6 new Rust unit tests in `crates/arvak-python/src/backend.rs`
- [x] 15/15 Python smoke tests (incl. end-to-end Qiskit
      QuantumCircuit → ArvakProvider → native sim with real Bell
      counts)
- [x] 52/52 pre-existing `tests/integrations/test_qiskit.py` +
      `tests/test_circuit.py` remain green
- [ ] CI: this PR's first run — observing
- [ ] Confirm Security Audit job (which has been failing on main since
      2026-06-13 on 11 advisories incl. RUSTSEC-2026-0097) is not
      newly broken by anything in this PR

## Out of scope
- Phase 1.5 design decisions (A1 timeout, A2 eager-vs-deferred) — to
  be settled before Phase 2 starts.
- Wiring `arvak-adapter-iqm` etc. via PyO3 — that's Phase 2+.
- Fixing the main-branch Security Audit failure — separate concern,
  pre-dates this PR.

## Notes on the branch
The branch name `fix-docker-hal-contract` is from the original PR #13
(merged 2026-04-16). Branch was kept around and accumulated this work.
Not renaming now to keep the PR URL stable — happy to rename if
preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)