### PR TITLE
chore(python): bump pyo3 0.28.2 → 0.29.0 (-2 security advisories)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -4395,18 +4395,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4414,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4426,13 +4426,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -15,7 +15,7 @@ default = ["simulator"]
 simulator = ["arvak-adapter-sim"]
 
 [dependencies]
-pyo3 = { version = "0.28.2", features = ["extension-module"] }
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
 arvak-ir = { workspace = true }
 arvak-compile = { workspace = true }
 arvak-qasm3 = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps `pyo3` from 0.28.2 to 0.29.0. Zero-cost drop-in: no code changes
needed, all tests stay green. Removes 2 of the 8 remaining
vulnerabilities from CI Security Audit.

## Why

PyO3 0.29.0 was released 2026-06-11 specifically to fix two advisories
filed the same day:

| Advisory | Issue | Affects | Patched |
|---|---|---|---|
| RUSTSEC-2026-0176 | OOB read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators | >= 0.24.0, < 0.29.0 | >= 0.29.0 |
| RUSTSEC-2026-0177 | Missing `Sync` bound on `PyCFunction::new_closure` (data races under free-threaded Python) | >= 0.15.0, < 0.29.0 | >= 0.29.0 |

We're not using the affected APIs in our code (`BoundListIterator::nth`/`nth_back`
or `PyCFunction::new_closure`), but the patched release is a clean
upgrade path and removes the advisories from the audit report.

PyO3 is a direct dep of `arvak-python` only (verified via
`grep '^pyo3 = ' --include=Cargo.toml` — single match).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo check -p arvak-python` green (5 pre-existing FromPyObject opt-in deprecation warnings unchanged from 0.28.x)
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `maturin develop --release`: wheel built clean for CPython 3.14
- [x] 52/52 pre-existing `tests/integrations/test_qiskit.py + test_circuit.py` pass
- [x] Inline smoke: `arvak.backend_for('sim').run(bell_qasm, 512).counts` returns correct Bell-state dominance
- [x] Inline smoke: `ArvakProvider().get_backend('sim').run(qc).result().get_counts()` returns correct dominance
- [ ] CI: this PR's run

## Expected audit reduction

```
before: 8 vulnerabilities, 4 allowed warnings
after:  6 vulnerabilities, 4 allowed warnings
```

The remaining 6 are all `rustls-webpki` (3 issues × 2 versions, pulled
transitively via aws-sdk → arvak-adapter-braket). That's the scope of
the next PR (aws-sdk bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)