### PR TITLE
chore(deps): close 4 audit warnings — rand bump, indicatif 0.18, paste ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "async-trait",
  "ndarray",
  "num-complex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -363,7 +363,7 @@ version = "1.9.5"
 dependencies = [
  "arvak-compile",
  "arvak-ir",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -392,7 +392,7 @@ dependencies = [
  "arvak-sched",
  "chrono",
  "clap",
- "console",
+ "console 0.15.11",
  "dirs",
  "indicatif",
  "mimalloc",
@@ -460,10 +460,10 @@ dependencies = [
  "arvak-sched",
  "async-trait",
  "clap",
- "console",
+ "console 0.15.11",
  "indicatif",
  "num-complex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tokio",
@@ -596,7 +596,7 @@ dependencies = [
  "arvak-sim",
  "num-complex",
  "pyo3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -663,7 +663,7 @@ name = "arvak-sim"
 version = "1.9.5"
 dependencies = [
  "arvak-ir",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -1736,6 +1736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2284,7 +2296,7 @@ dependencies = [
  "num-traits",
  "private-gemm-x86",
  "pulp",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "reborrow",
@@ -3176,14 +3188,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time 1.1.0",
 ]
 
@@ -3231,7 +3243,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3650,7 +3662,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3685,7 +3697,7 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -3745,12 +3757,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -3848,7 +3854,7 @@ dependencies = [
  "opentelemetry",
  "ordered-float",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -4178,7 +4184,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4423,7 +4429,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4472,9 +4478,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4483,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4536,7 +4542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -4740,7 +4746,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "mime",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -4769,7 +4775,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5117,7 +5123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5245,7 +5251,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5544,7 +5550,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -5731,7 +5737,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
@@ -5802,6 +5808,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6073,7 +6085,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ anyhow = "1.0"
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
-indicatif = "0.17"
+indicatif = "0.18"
 console = "0.15"
 
 # HTTP
@@ -110,8 +110,8 @@ libloading = "0.8"
 # Allocator
 mimalloc = { version = "0.1", default-features = false }
 
-# Random
-rand = "0.8"
+# Random (>= 0.8.6 closes RUSTSEC-2026-0097 unsoundness; cf. audit.toml)
+rand = "0.8.6"
 
 # Testing
 proptest = "1.5"

--- a/audit.toml
+++ b/audit.toml
@@ -54,4 +54,26 @@ ignore = [
     #   Same as RUSTSEC-2026-0176 — bump pyo3 to >= 0.29.0 once the
     #   Rust toolchain in CI supports it.
     "RUSTSEC-2026-0177",
+
+    # ----------------------------------------------------------------
+    # RUSTSEC-2024-0436 — paste crate is no longer maintained.
+    # Severity: informational/unmaintained (not a vulnerability —
+    # cargo audit exits 0 with this present, but listing it here keeps
+    # the warning count at zero for clean CI summaries).
+    #
+    # Why ignored:
+    #   paste is a transitive proc-macro dep we never use directly. It
+    #   is pulled in through gemm (matrix multiplication kernels) ->
+    #   faer (tensor network linear algebra) -> arvak-proj. Upstream
+    #   gemm/pulp/faer would need to migrate to a maintained
+    #   alternative (e.g. pastey or std `concat_idents!` once it
+    #   stabilises). Confirmed via `cargo tree --invert paste` on
+    #   2026-06-24 that we have no direct use.
+    #
+    # Removal path:
+    #   When faer/gemm/pulp drop the paste dependency (track gemm
+    #   upstream at https://github.com/sarah-quinones/gemm). Once
+    #   `cargo tree --invert paste` returns no matches in this
+    #   workspace, delete this entry.
+    "RUSTSEC-2024-0436",
 ]


### PR DESCRIPTION
## Summary

Closes the 4 yellow warnings remaining after #16/#18/#19. None of them
were vulnerabilities (cargo audit exited 0 with them present), but
three had clean fixes and the fourth gets a documented ignore.

| Advisory | Action | Result |
|---|---|---|
| RUSTSEC-2026-0097 (rand unsoundness) ×3 | bump workspace rand → 0.8.6, `cargo update -p rand@0.9.2` → 0.9.4 | gone |
| RUSTSEC-2025-0119 (number_prefix unmaintained) | bump indicatif 0.17 → 0.18 (drops number_prefix in favour of unit-prefix) | gone |
| RUSTSEC-2024-0436 (paste unmaintained) | transitive via gemm/pulp/faer, no direct use, no maintained drop-in upstream; added to audit.toml with rationale + removal path | ignored with documentation |

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-cli`: 41 passed
- [x] Local `cargo audit` with the (now three) ignores from audit.toml: **0 vulnerabilities, 0 warnings, exit 0**
- [x] Lockfile: rand 0.8.6 + 0.9.4 (both patched), number_prefix removed, unit-prefix 0.5.2 added, paste 1.0.15 still present (ignored)
- [ ] CI: this PR's run

## Composed end-state for main

After #15/#16/#18/#19 + this PR:

```
cargo audit  →  0 errors, 0 warnings, exit 0
Cargo.lock   →  -350 lines net since 2026-06-13
Documented ignores in audit.toml: 3
  - RUSTSEC-2026-0176 (pyo3 nth/nth_back) — removed when Rust ≥ 1.91
  - RUSTSEC-2026-0177 (pyo3 closure Sync) — removed when Rust ≥ 1.91
  - RUSTSEC-2024-0436 (paste unmaintained) — removed when gemm/pulp/faer migrate
```

Each ignore has a written rationale and a removal-path entry so the
audit.toml doesn't quietly grow over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)