### PR TITLE
feat(python): RFC-0001 Phase 1.5 — A1 result(timeout) + A2 deferred ArvakJob

### DIFF
--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -472,28 +472,38 @@ class ArvakBackend:
         return self._native.validate(qasm)
 
     def run(self, circuits, shots: int = 1024, **options) -> 'ArvakJob':
-        """Submit one or many Qiskit circuits and block until results are in.
+        """Submit one or many Qiskit circuits; return a deferred job handle.
+
+        This method submits each circuit and **returns immediately** with
+        a job wrapper. Results are fetched on ``job.result()``, which
+        blocks until the underlying HAL backends report completion. This
+        matches Qiskit ``JobV1`` semantics and is important for cloud
+        backends where jobs can sit in queue for hours.
+
+        For sim, ``submit`` + ``result`` are effectively instant so the
+        deferred-vs-eager distinction is invisible.
 
         Args:
             circuits: A single Qiskit ``QuantumCircuit`` or a list of them.
             shots: Number of measurement shots (default: 1024).
+            **options: ``parameters`` is forwarded to HAL ``submit()``.
 
         Returns:
-            An ``ArvakJob`` whose ``.result().get_counts(idx)`` returns the
-            measurement counts for circuit *idx* (defaults to 0).
+            An ``ArvakJob`` in deferred mode. Use ``job.result()`` to
+            block on completion, ``job.status()`` to poll, ``job.cancel()``
+            to abort.
         """
         if not isinstance(circuits, list):
             circuits = [circuits]
 
         parameters = options.get('parameters')  # forwarded to HAL submit()
 
-        all_counts: list[dict[str, int]] = []
-        for qc in circuits:
-            qasm = _qiskit_to_qasm3(qc)
-            exec_result = self._native.run(qasm, shots, parameters)
-            all_counts.append(dict(exec_result.counts))
+        handles = [
+            self._native.submit(_qiskit_to_qasm3(qc), shots, parameters)
+            for qc in circuits
+        ]
 
-        return ArvakJob(backend=self, counts=all_counts, shots=shots)
+        return ArvakJob(backend=self, shots=shots, handles=handles)
 
     def __repr__(self) -> str:
         return f"<ArvakBackend('{self.name}')>"
@@ -575,8 +585,8 @@ class ArvakSimulatorBackend:
 
         return ArvakJob(
             backend=self,
+            shots=shots,
             counts=all_counts,
-            shots=shots
         )
 
     def __repr__(self) -> str:
@@ -2267,29 +2277,126 @@ class ArvakQuantinuumJob:
 
 
 class ArvakJob:
-    """Job returned by ArvakSimulatorBackend.run().
+    """Job returned by an Arvak backend's ``run()``.
 
-    Contains real simulation results from the Rust statevector simulator.
+    Operates in one of two modes:
+
+    - **Eager mode** — constructed with ``counts=[...]``. Results are
+      already computed (used by ``ArvakSimulatorBackend`` and other
+      legacy vendor backend classes that compute eagerly).
+    - **Deferred mode** — constructed with ``handles=[...]``, where
+      each handle is an ``arvak.JobHandle`` from
+      ``backend.submit()``. Results are fetched lazily on
+      ``.result()``, allowing the caller to do other work between
+      submission and result retrieval. This is the path
+      ``ArvakBackend`` (the native HAL-backed class) uses.
+
+    Either ``counts`` *or* ``handles`` must be passed; passing both is
+    a programming error.
     """
 
-    def __init__(self, backend, counts, shots):
+    def __init__(self, backend, shots, counts=None, handles=None):
+        if (counts is None) == (handles is None):
+            raise ValueError(
+                "ArvakJob requires exactly one of `counts` (eager) or "
+                "`handles` (deferred)"
+            )
         self._backend = backend
-        self._counts = counts  # list[Dict[str, int]], one per circuit
         self._shots = shots
+        # Eager-mode state:
+        self._counts = counts  # list[dict[str,int]] or None
+        # Deferred-mode state:
+        self._handles = handles  # list[arvak.JobHandle] or None
+        self._cached_counts: list[dict[str, int]] | None = None
 
-    def result(self) -> 'ArvakResult':
-        """Get job result."""
+    def _is_deferred(self) -> bool:
+        return self._handles is not None
+
+    def result(self, timeout: float | None = None,
+               poll_interval_ms: int = 500) -> 'ArvakResult':
+        """Block until all circuits have completed; return aggregated result.
+
+        Args:
+            timeout: Maximum seconds to wait, applied per-handle. ``None``
+                waits forever (matches Qiskit ``JobV1.result()`` semantics
+                for cloud-vendor jobs with long queue times). Ignored in
+                eager mode (results are already available).
+            poll_interval_ms: Polling cadence forwarded to each handle's
+                ``result()`` call. Default 500 ms. Ignored in eager mode.
+
+        Returns:
+            ``ArvakResult`` whose ``.get_counts(idx)`` returns the counts
+            dict for circuit at index ``idx``.
+        """
+        if self._is_deferred():
+            if self._cached_counts is None:
+                self._cached_counts = [
+                    dict(h.result(timeout=timeout,
+                                  poll_interval_ms=poll_interval_ms).counts)
+                    for h in self._handles
+                ]
+            counts = self._cached_counts
+        else:
+            counts = self._counts
+
         return ArvakResult(
             backend_name=self._backend.name,
-            counts=self._counts,
-            shots=self._shots
+            counts=counts,
+            shots=self._shots,
         )
 
     def status(self) -> str:
-        return "DONE"
+        """Aggregate status across all submitted circuits.
+
+        Eager mode returns ``"DONE"`` (results were computed at construction).
+        Deferred mode polls each handle's status and aggregates:
+        - ``"DONE"`` — every handle is completed.
+        - ``"ERROR"`` — any handle reports failed.
+        - ``"CANCELLED"`` — any handle reports cancelled.
+        - ``"RUNNING"`` — at least one handle is running, none failed.
+        - ``"QUEUED"`` — all handles are still queued.
+        """
+        if not self._is_deferred():
+            return "DONE"
+
+        states = [h.status().state for h in self._handles]
+        if any(s == "failed" for s in states):
+            return "ERROR"
+        if any(s == "cancelled" for s in states):
+            return "CANCELLED"
+        if all(s == "completed" for s in states):
+            return "DONE"
+        if any(s == "running" for s in states):
+            return "RUNNING"
+        return "QUEUED"
+
+    def cancel(self) -> None:
+        """Cancel all in-flight handles. No-op in eager mode."""
+        if not self._is_deferred():
+            return
+        for h in self._handles:
+            try:
+                h.cancel()
+            except Exception:  # noqa: BLE001 — best-effort cancellation
+                pass
+
+    def job_id(self) -> str | list[str]:
+        """Return the underlying HAL job id(s). Empty string in eager mode.
+
+        Returns a single string when only one circuit was submitted,
+        a list of strings for multi-circuit batches.
+        """
+        if not self._is_deferred():
+            return ""
+        ids = [h.job_id for h in self._handles]
+        return ids[0] if len(ids) == 1 else ids
 
     def __repr__(self) -> str:
-        return f"<ArvakJob(circuits={len(self._counts)}, shots={self._shots})>"
+        if self._is_deferred():
+            return (f"<ArvakJob(deferred, circuits={len(self._handles)}, "
+                    f"shots={self._shots}, status={self.status()})>")
+        return (f"<ArvakJob(eager, circuits={len(self._counts)}, "
+                f"shots={self._shots})>")
 
 
 class ArvakResult:

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -24,6 +24,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 use pyo3::exceptions::{
     PyConnectionError, PyPermissionError, PyRuntimeError, PyTimeoutError, PyValueError,
@@ -427,14 +428,52 @@ impl PyJobHandle {
 
     /// Block until the job completes, then return the result.
     ///
-    /// Uses the HAL `wait()` default implementation (500 ms poll interval,
-    /// 5-minute timeout). For shot-only simulators this returns essentially
-    /// immediately.
-    fn result(&self, py: Python<'_>) -> PyResult<PyExecutionResult> {
+    /// Polls `status()` at `poll_interval_ms` cadence until terminal,
+    /// then fetches `result()`. Unlike the HAL `wait()` default (which
+    /// has a 5-minute hard cap), this method has no built-in timeout —
+    /// passing `timeout=None` (the default) waits indefinitely, matching
+    /// Qiskit `JobV1.result()` semantics for cloud-vendor jobs that can
+    /// sit in queue for hours.
+    ///
+    /// Args:
+    ///   timeout: maximum seconds to wait. `None` means wait forever.
+    ///   poll_interval_ms: cadence of `status()` polls (default 500 ms).
+    ///
+    /// Raises:
+    ///   `TimeoutError` if `timeout` elapses before the job reaches a
+    ///   terminal state.
+    #[pyo3(signature = (timeout=None, poll_interval_ms=500))]
+    fn result(
+        &self,
+        timeout: Option<f64>,
+        poll_interval_ms: u64,
+        py: Python<'_>,
+    ) -> PyResult<PyExecutionResult> {
         let backend = self.backend.clone();
         let job_id = self.job_id.clone();
+        let poll = Duration::from_millis(poll_interval_ms.max(1));
+        let deadline = timeout.map(|s| Instant::now() + Duration::from_secs_f64(s.max(0.0)));
+
         let res = py
-            .detach(move || runtime().block_on(async move { backend.wait(&job_id).await }))
+            .detach(move || {
+                runtime().block_on(async move {
+                    loop {
+                        match backend.status(&job_id).await? {
+                            JobStatus::Completed => return backend.result(&job_id).await,
+                            JobStatus::Failed(m) => return Err(HalError::JobFailed(m)),
+                            JobStatus::Cancelled => return Err(HalError::JobCancelled),
+                            JobStatus::Queued | JobStatus::Running => {
+                                if let Some(d) = deadline
+                                    && Instant::now() >= d
+                                {
+                                    return Err(HalError::Timeout(job_id.0.clone()));
+                                }
+                                tokio::time::sleep(poll).await;
+                            }
+                        }
+                    }
+                })
+            })
             .map_err(hal_to_py_err)?;
         Ok(PyExecutionResult {
             inner: Arc::new(res),
@@ -442,8 +481,14 @@ impl PyJobHandle {
     }
 
     /// Alias for [`Self::result`] (Qiskit `JobV1` compat).
-    fn wait(&self, py: Python<'_>) -> PyResult<PyExecutionResult> {
-        self.result(py)
+    #[pyo3(signature = (timeout=None, poll_interval_ms=500))]
+    fn wait(
+        &self,
+        timeout: Option<f64>,
+        poll_interval_ms: u64,
+        py: Python<'_>,
+    ) -> PyResult<PyExecutionResult> {
+        self.result(timeout, poll_interval_ms, py)
     }
 
     fn __repr__(&self) -> String {
@@ -551,17 +596,21 @@ impl PyBackend {
 
     /// Submit + wait + fetch — convenience wrapper.
     ///
-    /// Equivalent to `backend.submit(qasm, shots, parameters).result()`.
-    #[pyo3(signature = (qasm, shots=1024, parameters=None))]
+    /// Equivalent to `backend.submit(qasm, shots, parameters).result(timeout)`.
+    /// For deferred submission (return immediately, fetch later), call
+    /// `.submit()` directly.
+    #[pyo3(signature = (qasm, shots=1024, parameters=None, timeout=None, poll_interval_ms=500))]
     fn run(
         &self,
         qasm: &str,
         shots: u32,
         parameters: Option<HashMap<String, f64>>,
+        timeout: Option<f64>,
+        poll_interval_ms: u64,
         py: Python<'_>,
     ) -> PyResult<PyExecutionResult> {
         let handle = self.submit(qasm, shots, parameters, py)?;
-        handle.result(py)
+        handle.result(timeout, poll_interval_ms, py)
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
## Summary

Implements the two BLOCKING design decisions from RFC-0001 §Phase 1.5,
both confirmed 2026-06-25:

- **A1 — Option 1** confirmed: PyO3-level polling loop in
  `PyJobHandle.result(timeout=None)`. `None` waits forever. Replaces
  the HAL `wait()` 5-minute hard cap.
- **A2 — Option 1+3 hybrid** confirmed: `ArvakBackend.run()` returns
  immediately with a deferred `ArvakJob` wrapping a list of
  `PyJobHandle`s. `.result()` blocks lazily. Multi-circuit batches
  are first-class.

Sim behavior is identical from a user's perspective (sim is instant
either way). All cloud-vendor blockers identified at the end of Phase 1
are removed — Phase 2 (IQM) can now wire cloud backends without
breaking the timeout cap or `run()` blocking semantics.

## What changed

**Rust** (`crates/arvak-python/src/backend.rs`):

- `PyJobHandle::result(timeout=None, poll_interval_ms=500)` —
  own polling loop calling `backend.status()` + `backend.result()`,
  honors optional `timeout`.
- `PyJobHandle::wait(...)` — alias with same signature.
- `PyBackend::run(qasm, shots, parameters, timeout=None,
  poll_interval_ms=500)` — forwards the new args.

**Python** (`crates/arvak-python/python/arvak/integrations/qiskit/backend.py`):

- `ArvakJob` is now dual-mode:
  - Eager: legacy `ArvakSimulatorBackend.run()` keeps using `counts=[...]`
    constructor arg; `status()` returns `"DONE"`, `result()` returns
    immediately.
  - Deferred: new `ArvakBackend.run()` uses `handles=[...]`; `status()`
    aggregates per-handle into `DONE`/`ERROR`/`CANCELLED`/`RUNNING`/
    `QUEUED`; `result(timeout=None)` blocks lazily and caches; `cancel()`
    iterates handles best-effort; `job_id()` returns one string for
    single-circuit, list for multi-circuit.
  - Constructor enforces exactly-one-of `counts`/`handles` (`ValueError`).
- `ArvakBackend.run()` now submits each circuit via the native
  `submit()` and returns immediately with a deferred job.
- `ArvakSimulatorBackend.run()` updated to the new `ArvakJob` keyword
  signature (still eager).

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo check --workspace --exclude arvak-python` green.
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed.
- [x] `maturin develop --release`: wheel built clean.
- [x] 52/52 pre-existing `tests/integrations/test_qiskit.py +
      test_circuit.py` pass — sim behavior unchanged from user view.
- [x] 13/13 new Phase-1.5 smoke tests cover:
  - A1: default timeout=None, explicit timeout, `wait()` alias,
    `backend.run()` forwarding
  - A2: deferred-mode repr / status / result / caching / multi-circuit
    indexing / job_id / cancel
  - Compat: eager-mode `ArvakSimulatorBackend` still works
  - Invariant: `ArvakJob` constructor rejects both/neither args
- [ ] CI: this PR's run.

## What this does NOT change

- Sim path is functionally identical (instant completion makes the
  deferred-vs-eager distinction invisible to sim callers).
- No changes to native Rust HAL `Backend` trait or any adapter.
- The legacy `ArvakIBMBackend` / `ArvakIQMResonanceBackend` etc. are
  unaffected — Phase 2+ replaces them with `ArvakBackend(name)`.

## What this unblocks

Phase 2 (IQM Resonance) per RFC §Phase 2. Native adapter wiring + qiskit
+ qrisp integration swap can land in the next PR without revisiting
A1/A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)