### PR TITLE
feat(python): RFC-0001 Phase 2a — native IQM Resonance, kill iqm-client[qiskit] bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
 name = "arvak-python"
 version = "1.9.5"
 dependencies = [
+ "arvak-adapter-iqm",
  "arvak-adapter-sim",
  "arvak-compile",
  "arvak-hal",

--- a/adapters/arvak-adapter-iqm/src/backend.rs
+++ b/adapters/arvak-adapter-iqm/src/backend.rs
@@ -68,16 +68,20 @@ impl IqmBackend {
     }
 
     /// Create a backend targeting a specific IQM device.
+    ///
+    /// `Backend::name()` will return `"iqm_<target>"` so multiple IQM
+    /// instances in the same process remain distinguishable to callers.
     pub fn with_target(target: impl Into<String>) -> IqmResult<Self> {
         let token = std::env::var("IQM_TOKEN").map_err(|_| IqmError::MissingToken)?;
+        let target_str: String = target.into();
 
-        let mut config = BackendConfig::new("iqm")
+        let mut config = BackendConfig::new(format!("iqm_{}", target_str))
             .with_endpoint(DEFAULT_ENDPOINT)
             .with_token(&token);
 
         config
             .extra
-            .insert("target".into(), serde_json::json!(target.into()));
+            .insert("target".into(), serde_json::json!(target_str));
 
         Self::from_config_impl(config)
     }
@@ -115,7 +119,18 @@ impl IqmBackend {
 
         let client = IqmClient::new(endpoint, token)?;
 
-        let capabilities = Capabilities::iqm(&target, 20);
+        // Per-target qubit counts for known IQM Resonance machines.
+        // Falls back to 20 (Garnet, the most common default) for unknown
+        // targets so we stay conservative on capacity reporting. The
+        // adapter's TTL-cached `backend_info` query overrides this at
+        // runtime once the HTTP API answers — these defaults are only
+        // used until the first successful availability/backend-info call.
+        let num_qubits = match target.to_ascii_lowercase().as_str() {
+            "sirius" => 16,
+            "emerald" | "crystal" => 54,
+            _ => 20,
+        };
+        let capabilities = Capabilities::iqm(&target, num_qubits);
 
         Ok(Self {
             config,

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,8 +11,9 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator"]
+default = ["simulator", "adapter-iqm"]
 simulator = ["arvak-adapter-sim"]
+adapter-iqm = ["arvak-adapter-iqm"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -21,6 +22,7 @@ arvak-compile = { workspace = true }
 arvak-qasm3 = { workspace = true }
 arvak-hal = { workspace = true }
 arvak-adapter-sim = { workspace = true, optional = true }
+arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -298,14 +298,15 @@ class ArvakProvider:
                     f"SCALEWAY_SESSION_ID environment variables."
                 ) from e
 
-        # Lazily create IQM Resonance backends on demand
+        # Lazily create IQM Resonance backends on demand — Phase 2a:
+        # routes through the native arvak-adapter-iqm via PyO3, no longer
+        # imports iqm-client[qiskit]. See RFC-0001 Phase 2.
         if name and name in self._IQM_RESONANCE_BACKENDS and name not in self._backends:
             try:
-                computer = self._IQM_RESONANCE_COMPUTER_MAP[name]
-                self._backends[name] = ArvakIQMResonanceBackend(
-                    provider=self, computer=computer,
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
                 )
-            except (ValueError, ImportError) as e:
+            except (ValueError, RuntimeError, ConnectionError) as e:
                 raise ValueError(
                     f"Cannot connect to {name}: {e}. "
                     f"Set IQM_TOKEN environment variable (from resonance.meetiqm.com)."
@@ -1404,6 +1405,15 @@ class ArvakScalewayBackend:
 class ArvakIQMResonanceBackend:
     """Arvak IQM Resonance backend — submits directly to IQM's cloud API.
 
+    .. deprecated:: 2.1
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('iqm_garnet')`` now returns the
+        native-HAL-backed class automatically (Phase 2a). Direct
+        instantiation of this class still works but will be removed in
+        a future release. The native path no longer requires
+        ``iqm-client[qiskit]`` — IQM Resonance is reached through
+        ``arvak-adapter-iqm`` (Rust REST client) via PyO3.
+
     Uses qiskit-on-iqm (iqm-client[qiskit]) for transpilation and submission.
     Arvak provides qubit routing and gate compilation (PRX + CZ basis);
     iqm-client handles serialisation to IQM's native JSON format and auth.
@@ -1419,6 +1429,15 @@ class ArvakIQMResonanceBackend:
     }
 
     def __init__(self, provider: ArvakProvider, computer: str = "sirius"):
+        import warnings
+        warnings.warn(
+            "ArvakIQMResonanceBackend is deprecated; "
+            "ArvakProvider.get_backend('iqm_*') now returns ArvakBackend "
+            "(native HAL-backed, no iqm-client dependency). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             from iqm.qiskit_iqm import IQMProvider as _IQMProvider
         except ImportError as exc:

--- a/crates/arvak-python/python/arvak/integrations/qrisp/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qrisp/backend.py
@@ -5,15 +5,13 @@ Arvak circuits through Qrisp's backend API.
 
 Supported backends:
   - 'sim'      : Arvak's built-in Rust statevector simulator (no credentials)
-  - 'iqm'      : IQM Resonance QPU via iqm-client / qiskit-iqm (requires IQM_TOKEN)
+  - 'iqm'      : IQM Resonance QPU via the native arvak-adapter-iqm
+                 (requires IQM_TOKEN; no qiskit-iqm dependency)
   - 'scaleway' : Scaleway QaaS (IQM QPU) via REST API (requires SCALEWAY credentials)
 """
 
 import os
 from typing import Optional, Union
-
-# IQM Resonance endpoint
-_IQM_RESONANCE_URL = "https://resonance.meetiqm.com/"
 
 # IQM topology coupling maps (qubit count and connectivity style)
 # Sirius  : 16-qubit  star topology  (QPU-SIRIUS-24PQ physical, 16 usable)
@@ -136,15 +134,21 @@ class ArvakBackendClient:
         return arvak.run_sim(arvak_circuit, shots)
 
     def _run_iqm(self, arvak_circuit, shots: int, **options) -> dict[str, int]:
-        """Compile with Arvak and submit to IQM Resonance.
+        """Compile with Arvak and submit to IQM Resonance via the native adapter.
+
+        Phase 2a: no longer imports ``iqm.qiskit_iqm``. Submission goes
+        through the native Rust ``arvak-adapter-iqm`` (REST against
+        ``https://api.resonance.meetiqm.com``) reached via
+        ``arvak.backend_for("iqm_<computer>")``.
 
         Requires:
           - ``IQM_TOKEN``    env var (Resonance bearer token)
-          - ``IQM_COMPUTER`` env var (default: 'sirius'; options: garnet, emerald)
-          - ``iqm-client`` and ``qiskit-iqm`` Python packages
+          - ``IQM_COMPUTER`` env var (default: ``'sirius'``;
+            options: ``garnet``, ``emerald``, ``crystal``)
 
         The circuit is routed and gate-translated by Arvak's Rust compiler
-        for the selected IQM topology, then submitted via ``qiskit-iqm``.
+        for the selected IQM topology, then submitted via PyO3 to the
+        native adapter — no qiskit-iqm involved.
         """
         import arvak
 
@@ -160,12 +164,13 @@ class ArvakBackendClient:
         num_qubits = topo_info['qubits']
         topology = topo_info['topology']
 
-        # Compile circuit with Arvak for the target IQM topology
+        # Compile circuit with Arvak for the target IQM topology.
+        # This keeps the same per-vendor compile step the legacy code had —
+        # Arvak's compiler handles layout / routing / basis translation
+        # before the QASM3 is handed to the native adapter for HTTP submit.
         if topology == 'star':
             coupling = arvak.CouplingMap.star(num_qubits)
         else:
-            # crystal topology — use linear approximation until CouplingMap.crystal
-            # is available; the compiler will handle remapping
             coupling = arvak.CouplingMap.linear(num_qubits)
 
         basis = arvak.BasisGates.iqm()
@@ -176,34 +181,14 @@ class ArvakBackendClient:
             optimization_level=options.get('optimization_level', 1),
         )
 
-        # Export compiled circuit to QASM3
         qasm_str = arvak.to_qasm(compiled)
 
-        # Submit to IQM Resonance via qiskit-iqm
-        try:
-            from iqm.qiskit_iqm import IQMProvider
-            from qiskit import QuantumCircuit as QiskitCircuit, transpile
-            from qiskit.qasm3 import loads as qasm3_loads
-        except ImportError as exc:
-            raise ImportError(
-                "IQM backend requires 'iqm-client' and 'qiskit-iqm' packages.\n"
-                "Install with: pip install iqm-client qiskit-iqm"
-            ) from exc
-
-        # Parse compiled QASM back to Qiskit for submission
-        qiskit_circuit = qasm3_loads(qasm_str)
-
-        provider = IQMProvider(
-            _IQM_RESONANCE_URL,
-            quantum_computer=computer,
-        )
-        backend = provider.get_backend()
-        qc_transpiled = transpile(qiskit_circuit, backend=backend, optimization_level=0)
-
-        job = backend.run(qc_transpiled, shots=shots)
-        result = job.result()
-        counts = result.get_counts()
-        return dict(counts)
+        # Submit to IQM Resonance via the native Rust adapter — no Qiskit /
+        # qiskit-iqm in the path. The adapter reads IQM_TOKEN itself.
+        backend = arvak.backend_for(f"iqm_{computer}")
+        handle = backend.submit(qasm_str, shots)
+        result = handle.result()  # blocks until done, no fixed timeout
+        return dict(result.counts)
 
     def _run_scaleway(self, arvak_circuit, shots: int, **options) -> dict[str, int]:
         """Compile with Arvak and submit to Scaleway QaaS (IQM QPU).

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -626,9 +626,18 @@ impl PyBackend {
 // Backend registry — builds backends by name
 // ---------------------------------------------------------------------------
 
-/// Construct a backend by name. Phase 1 supports `"sim"` only.
+/// Construct a backend by name.
 ///
-/// Future phases will add IBM/IQM/Quantinuum/etc. behind feature flags.
+/// Supported as of Phase 2a:
+///   - `"sim"` / `"simulator"` / `"arvak_simulator"` — local statevector
+///     simulator (feature `simulator`, on by default).
+///   - `"iqm_garnet"` / `"iqm_sirius"` / `"iqm_emerald"` / `"iqm_crystal"`
+///     — IQM Resonance cloud machines (feature `adapter-iqm`, on by
+///     default). Auth via `IQM_TOKEN` env var.
+///
+/// LUMI Helmi / LRZ paths (OIDC-authenticated) are out of scope for
+/// 2a — they need the missing `IqmBackend::with_oidc()` glue (RFC
+/// Phase 2b).
 fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> {
     match name {
         "sim" | "arvak_simulator" | "simulator" => {
@@ -643,6 +652,28 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        n if n.starts_with("iqm_") => {
+            #[cfg(feature = "adapter-iqm")]
+            {
+                // Strip the "iqm_" prefix to get the target name the
+                // native adapter expects ("garnet", "sirius", etc.).
+                let target = &n["iqm_".len()..];
+                if target.is_empty() {
+                    return Err(HalError::Configuration(format!(
+                        "invalid IQM backend name: {n} (expected 'iqm_<target>', e.g. 'iqm_garnet')"
+                    )));
+                }
+                let backend = arvak_adapter_iqm::IqmBackend::with_target(target)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-iqm"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "IQM adapter not compiled in for backend {n} (enable 'adapter-iqm' feature)"
+                )))
+            }
+        }
         other => Err(HalError::Configuration(format!(
             "unknown backend: {other} (known: {})",
             known_backends().join(", ")
@@ -651,11 +682,21 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
 }
 
 /// List backend names known to this build.
+///
+/// Reports the *canonical* names a caller can pass to
+/// [`make_backend`]. IQM backends use the `iqm_<target>` form.
 fn known_backends() -> Vec<String> {
     let mut v: Vec<String> = Vec::new();
     #[cfg(feature = "simulator")]
     {
         v.push("sim".into());
+    }
+    #[cfg(feature = "adapter-iqm")]
+    {
+        v.push("iqm_garnet".into());
+        v.push("iqm_sirius".into());
+        v.push("iqm_emerald".into());
+        v.push("iqm_crystal".into());
     }
     v
 }


### PR DESCRIPTION
## Summary

Phase 2a of RFC-0001. `ArvakProvider.get_backend('iqm_*')` (qiskit
integration) and `ArvakBackendClient('iqm')` (qrisp integration) now
**both route through the native Rust `arvak-adapter-iqm` via PyO3**.
Removes the last in-Arvak path that imported `iqm.qiskit_iqm.IQMProvider`
to reach IQM hardware.

The hardware path is now: **Arvak compiler → native adapter (REST) →
IQM Resonance**. No qiskit-iqm or iqm-client in the middle. Both
framework surfaces keep their existing user-facing API; only the
implementation underneath changes.

LUMI Helmi / LRZ OIDC paths are **out of scope** here — they need the
missing `IqmBackend::with_oidc(config, target)` glue (Phase 2b).

## What changed

| Component | Change |
|---|---|
| **Cargo feature** | New `adapter-iqm = ["arvak-adapter-iqm"]`, added to `default` so `pip install arvak` ships IQM out of the box |
| **`make_backend()`** | Prefix branch for `iqm_<target>` (garnet/sirius/emerald/crystal) |
| **`IqmBackend::with_target(target)`** | `Backend::name()` now returns `iqm_<target>` so multiple IQM instances stay distinguishable; previously all reported just `iqm` |
| **`IqmBackend` capabilities** | Per-target qubit counts hardcoded (sirius=16, garnet=20, emerald/crystal=54) — fixes the regression risk where legacy class had this but native adapter hardcoded 20 for all |
| **qiskit `ArvakProvider.backends()`** | IQM branch constructs `ArvakBackend(provider, name)` instead of `ArvakIQMResonanceBackend(...)` |
| **`ArvakIQMResonanceBackend`** | Importable, emits `DeprecationWarning` at construction |
| **qrisp `_run_iqm`** | Removed `iqm.qiskit_iqm` / `qiskit.transpile` / `qiskit.qasm3.loads`. After Arvak's compile pass, QASM3 goes to `arvak.backend_for(f"iqm_{computer}").submit(...)` and `handle.result()` |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-iqm --lib`: 25 passed
- [x] 52 pre-existing tests (qiskit-integration + circuit): all pass
- [x] 13 Phase-1.5 smoke tests (A1/A2): all pass (no regression)
- [x] 10 new Phase-2a smoke tests:
  - registry lists `iqm_garnet/sirius/emerald/crystal`
  - missing `IQM_TOKEN` raises with helpful error message
  - per-target qubit counts correct (16/20/54/54)
  - empty target name rejected with helpful error
  - PRX/CZ basis exposed
  - `ArvakProvider.get_backend('iqm_garnet')` returns `ArvakBackend` (not legacy)
  - legacy `ArvakIQMResonanceBackend` emits `DeprecationWarning`
  - qrisp module loads without pulling in `iqm.qiskit_iqm`
  - qrisp `_run_iqm` body uses `arvak.backend_for` (source-inspection)
  - sim path unchanged
- [ ] CI: this PR's run

## No live IQM-hardware calls in tests

All assertions are static / metadata / error-path. Construction with
a dummy `IQM_TOKEN` validates the build-path but doesn't submit. Per
the project memory rule, real hardware calls require explicit
per-session permission — none happen here.

## What stays the same

- User-facing API unchanged:
  `provider.get_backend('iqm_garnet').run(qc)` and
  `ArvakBackendClient('iqm').run_circuit(qc)` work as before.
- `IQM_TOKEN` is still the auth env var.
- Arvak's compile pass (layout / routing / basis-translation for PRX+CZ)
  runs as before — that's the compiler value-add, separate from
  submission.

## What stays for Phase 2b

LUMI Helmi via CSC OIDC + LRZ via OIDC. The native adapter has
`OidcConfig::lumi(project_id)` / `OidcConfig::lrz(project_id)` and
`OidcAuth`, but `IqmBackend::with_oidc()` is documented in lib.rs and
not implemented. Phase 2b adds that constructor, exposes
`arvak.backend_for("iqm_helmi")` etc., and handles the
non-interactive token flow for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)