### PR TITLE
feat(iqm): RFC-0001 Phase 2b — IqmBackend::with_oidc + LUMI Helmi / LRZ in registry

### DIFF
--- a/adapters/arvak-adapter-iqm/src/backend.rs
+++ b/adapters/arvak-adapter-iqm/src/backend.rs
@@ -9,7 +9,8 @@ use tracing::{debug, info, instrument};
 
 use arvak_hal::{
     Backend, BackendAvailability, BackendConfig, BackendFactory, Capabilities, Counts,
-    ExecutionResult, HalError, HalResult, Job, JobId, JobStatus, ValidationResult,
+    ExecutionResult, HalError, HalResult, Job, JobId, JobStatus, OidcAuth, OidcConfig,
+    ValidationResult,
 };
 use arvak_ir::Circuit;
 
@@ -92,15 +93,65 @@ impl IqmBackend {
         token: impl Into<String>,
         target: impl Into<String>,
     ) -> IqmResult<Self> {
-        let mut config = BackendConfig::new("iqm")
+        let target_str: String = target.into();
+        let mut config = BackendConfig::new(format!("iqm_{}", target_str))
             .with_endpoint(endpoint)
             .with_token(token);
 
         config
             .extra
-            .insert("target".into(), serde_json::json!(target.into()));
+            .insert("target".into(), serde_json::json!(target_str));
 
         Self::from_config_impl(config)
+    }
+
+    /// Create a backend authenticated via OIDC (LUMI Helmi / LRZ).
+    ///
+    /// Reads a cached OIDC token (from a prior interactive `arvak auth
+    /// login` session) and uses it as the bearer for IQM Resonance
+    /// REST calls. If no valid cached token is found, returns an
+    /// authentication error pointing the user at the login command.
+    ///
+    /// The endpoint URL is required and must be provided by the
+    /// caller — LUMI's URL is delivered via the `HELMI_CORTEX_URL`
+    /// environment variable inside the LUMI module environment; LRZ
+    /// users get theirs from the LRZ documentation.
+    ///
+    /// # Limitation
+    ///
+    /// The bearer token is fetched once at construction. For very
+    /// long-running jobs (≫ 1 hour) that exceed the OIDC access
+    /// token lifetime, the in-flight HTTP call may fail with 401 and
+    /// the user must reconstruct the backend (which triggers
+    /// auto-refresh from the cached refresh token via `OidcAuth`).
+    /// A proper auto-refresh path is future work.
+    pub fn with_oidc(
+        config: OidcConfig,
+        target: impl Into<String>,
+        endpoint: impl Into<String>,
+    ) -> IqmResult<Self> {
+        let auth = OidcAuth::new(config)
+            .map_err(|e| IqmError::AuthFailed(format!("OIDC handler init failed: {e}")))?;
+
+        // Sync block on the async get_token. OidcAuth tries cache → refresh
+        // and only fails if no valid path is available.
+        let rt = tokio::runtime::Handle::try_current().ok();
+        let token = if let Some(handle) = rt {
+            // We're already inside a tokio runtime (PyO3 wrapper path) —
+            // block_in_place + handle.block_on, or just use the handle.
+            // Safest: spawn a temporary runtime on the current thread.
+            tokio::task::block_in_place(|| handle.block_on(auth.get_token()))
+        } else {
+            // Standalone Rust caller — build a private runtime.
+            let private_rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| IqmError::AuthFailed(format!("runtime build failed: {e}")))?;
+            private_rt.block_on(auth.get_token())
+        }
+        .map_err(|e| IqmError::AuthFailed(format!("OIDC token fetch failed: {e}")))?;
+
+        Self::with_credentials(endpoint, token, target)
     }
 
     fn from_config_impl(config: BackendConfig) -> IqmResult<Self> {

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -652,6 +652,78 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // LUMI Helmi at CSC Finland — IQM hardware via CSC OIDC auth.
+        // Endpoint comes from HELMI_CORTEX_URL (set by LUMI's helmi_qiskit
+        // module) so we don't hardcode a private URL. Project ID comes
+        // from LUMI_PROJECT_ID. Initial OIDC login is handled by `arvak
+        // auth login` (out-of-band, browser-based); this call reads the
+        // cached token and refreshes via refresh-token if needed.
+        "iqm_helmi" => {
+            #[cfg(feature = "adapter-iqm")]
+            {
+                let endpoint = std::env::var("HELMI_CORTEX_URL").map_err(|_| {
+                    HalError::Configuration(
+                        "HELMI_CORTEX_URL not set — LUMI's helmi_qiskit module \
+                         sets this env var when loaded. For local use outside \
+                         LUMI, set it manually to the Helmi Cortex API URL."
+                            .into(),
+                    )
+                })?;
+                let project_id = std::env::var("LUMI_PROJECT_ID").map_err(|_| {
+                    HalError::Configuration(
+                        "LUMI_PROJECT_ID not set — required for CSC OIDC auth. \
+                         Use the project ID you applied for on LUMI."
+                            .into(),
+                    )
+                })?;
+                let oidc = arvak_hal::OidcConfig::lumi(&project_id);
+                let backend = arvak_adapter_iqm::IqmBackend::with_oidc(oidc, "helmi", endpoint)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-iqm"))]
+            {
+                Err(HalError::Configuration(
+                    "IQM adapter not compiled in (enable 'adapter-iqm' feature)".into(),
+                ))
+            }
+        }
+        // LRZ-hosted IQM machines via LRZ OIDC.
+        // Endpoint from LRZ_IQM_URL, project from LRZ_PROJECT_ID.
+        // Target name follows pattern iqm_lrz_<machine>.
+        n if n.starts_with("iqm_lrz_") => {
+            #[cfg(feature = "adapter-iqm")]
+            {
+                let target = &n["iqm_lrz_".len()..];
+                if target.is_empty() {
+                    return Err(HalError::Configuration(format!(
+                        "invalid LRZ backend name: {n} (expected 'iqm_lrz_<machine>')"
+                    )));
+                }
+                let endpoint = std::env::var("LRZ_IQM_URL").map_err(|_| {
+                    HalError::Configuration(
+                        "LRZ_IQM_URL not set — required for LRZ-hosted IQM access. \
+                         See LRZ quantum-computing documentation for the URL."
+                            .into(),
+                    )
+                })?;
+                let project_id = std::env::var("LRZ_PROJECT_ID").map_err(|_| {
+                    HalError::Configuration(
+                        "LRZ_PROJECT_ID not set — required for LRZ OIDC auth.".into(),
+                    )
+                })?;
+                let oidc = arvak_hal::OidcConfig::lrz(&project_id);
+                let backend = arvak_adapter_iqm::IqmBackend::with_oidc(oidc, target, endpoint)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-iqm"))]
+            {
+                Err(HalError::Configuration(
+                    "IQM adapter not compiled in (enable 'adapter-iqm' feature)".into(),
+                ))
+            }
+        }
         n if n.starts_with("iqm_") => {
             #[cfg(feature = "adapter-iqm")]
             {
@@ -693,10 +765,15 @@ fn known_backends() -> Vec<String> {
     }
     #[cfg(feature = "adapter-iqm")]
     {
+        // IQM Resonance Cloud — token auth via IQM_TOKEN
         v.push("iqm_garnet".into());
         v.push("iqm_sirius".into());
         v.push("iqm_emerald".into());
         v.push("iqm_crystal".into());
+        // LUMI Helmi at CSC — OIDC auth via cached token
+        v.push("iqm_helmi".into());
+        // LRZ-hosted IQM machines — OIDC auth; users append machine name
+        // (e.g. iqm_lrz_<machine>). The bare "iqm_lrz_" form is invalid.
     }
     v
 }


### PR DESCRIPTION
## Summary

Implements the `IqmBackend::with_oidc()` constructor that Phase-1 docs
claimed but didn't ship, and wires `iqm_helmi` (CSC LUMI) and
`iqm_lrz_<machine>` (LRZ Munich) into the PyO3 backend registry.
Closes the LUMI/LRZ gap flagged at the start of Phase 2.

## What changed

**Adapter (Rust)**:
- New `IqmBackend::with_oidc(config, target, endpoint)`. Builds
  `OidcAuth` from `OidcConfig::lumi()` / `OidcConfig::lrz()`,
  synchronously fetches a bearer via `auth.get_token()` (cache →
  refresh-token → fail-with-guidance), then delegates to existing
  `with_credentials()`.
- Handles tokio context properly: uses `Handle::try_current()` so it
  works both inside the PyO3 runtime (sync-over-async) and standalone.
- `with_credentials()` also now sets `Backend::name()` to
  `iqm_<target>` for consistency.

**Registry (PyO3)**:
- `iqm_helmi` — reads `HELMI_CORTEX_URL` + `LUMI_PROJECT_ID`,
  constructs via `OidcConfig::lumi(project_id)`.
- `iqm_lrz_<machine>` — reads `LRZ_IQM_URL` + `LRZ_PROJECT_ID`,
  constructs via `OidcConfig::lrz(project_id)`.
- Each branch raises with a clear, env-var-specific error message
  when prerequisites are missing.

## Why env-var endpoints (not hardcoded URLs)

LUMI's Helmi cortex URL is published only via the `HELMI_CORTEX_URL`
env var that CSC's `helmi_qiskit` module sets at runtime. LRZ's URL is
similarly user-environment-specific. Requiring both via env var
matches upstream conventions and avoids embedding private URLs in the
public repo.

## Test plan

Live LUMI/LRZ submission untestable (no CSC/LRZ account). All
assertions static / metadata / error-path:

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo check -p arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-iqm --lib`: 25 passed (no regression)
- [x] 52 pre-existing qiskit + circuit tests pass
- [x] 10 new Phase-2b smoke tests cover:
  - registry lists `iqm_helmi`
  - `iqm_lrz_<machine>` pattern recognised
  - clear errors for each missing env var (`HELMI_CORTEX_URL`,
    `LUMI_PROJECT_ID`, `LRZ_IQM_URL`, `LRZ_PROJECT_ID`)
  - empty LRZ machine name rejected
  - clear auth error when env vars present but no cached OIDC token
  - Phase-2a `iqm_garnet` still works (no regression)
  - sim unchanged
- [ ] CI: this PR's run

## Limitations (documented, future work)

1. **Browser-based OIDC login** is out of scope. Phase 2b assumes the
   cached token is already on disk (from a prior `arvak auth login`
   session — that CLI command lives elsewhere).
2. **Long-job token refresh.** Bearer is fetched once at construction.
   Jobs that outlive the OIDC access-token lifetime (typically 1 h)
   may fail mid-flight with 401; users reconstruct the backend
   (refresh-token flow regenerates the bearer). Auto-refresh inside
   `IqmClient` is future work.
3. **No live tests.** No CSC/LRZ account available; smoke coverage is
   error-path only.

## What does NOT change

- Phase-2a `iqm_garnet/sirius/emerald/crystal` still works via
  `IQM_TOKEN`.
- Sim path unchanged.
- Qiskit / qrisp integrations: no further changes — they reach
  `iqm_helmi` and `iqm_lrz_<machine>` automatically via the same
  `arvak.backend_for(name)` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)