### PR TITLE
feat(python): RFC-0001 Phase 3 — native Scaleway QaaS, kill in-Python requests loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,7 @@ name = "arvak-python"
 version = "1.9.5"
 dependencies = [
  "arvak-adapter-iqm",
+ "arvak-adapter-scaleway",
  "arvak-adapter-sim",
  "arvak-compile",
  "arvak-hal",

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,9 +11,10 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
+adapter-scaleway = ["arvak-adapter-scaleway"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -23,6 +24,7 @@ arvak-qasm3 = { workspace = true }
 arvak-hal = { workspace = true }
 arvak-adapter-sim = { workspace = true, optional = true }
 arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
+arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -284,14 +284,15 @@ class ArvakProvider:
                     f"Set IBM_API_KEY and IBM_SERVICE_CRN environment variables."
                 ) from e
 
-        # Lazily create Scaleway backends on demand
+        # Lazily create Scaleway backends — Phase 3: native arvak-adapter-scaleway
+        # via PyO3. No more in-Python `requests` HTTP path.
+        # See RFC-0001 Phase 3.
         if name and name in self._SCALEWAY_BACKENDS and name not in self._backends:
             try:
-                platform = self._SCALEWAY_PLATFORM_MAP[name]
-                self._backends[name] = ArvakScalewayBackend(
-                    provider=self, platform=platform,
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
                 )
-            except (ValueError, ImportError) as e:
+            except (ValueError, RuntimeError, ConnectionError) as e:
                 raise ValueError(
                     f"Cannot connect to {name}: {e}. "
                     f"Set SCALEWAY_SECRET_KEY, SCALEWAY_PROJECT_ID, and "
@@ -1121,6 +1122,15 @@ class ArvakIBMJob:
 class ArvakScalewayBackend:
     """Arvak Scaleway/IQM backend with Qiskit-compatible interface.
 
+    .. deprecated:: 2.2
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('scaleway_garnet')`` now returns
+        the native-HAL-backed class automatically (Phase 3). Direct
+        instantiation of this class still works but will be removed in
+        a future release. The native path replaces the in-Python
+        ``requests`` HTTP loop with ``arvak-adapter-scaleway`` (Rust
+        REST client) reached via PyO3.
+
     Compiles circuits with Arvak's Rust compiler (PRX + CZ basis, star topology)
     and submits them to IQM hardware via Scaleway's QaaS REST API.
 
@@ -1145,6 +1155,15 @@ class ArvakScalewayBackend:
 
     def __init__(self, provider: ArvakProvider,
                  platform: str = "QPU-GARNET-20PQ"):
+        import warnings
+        warnings.warn(
+            "ArvakScalewayBackend is deprecated; "
+            "ArvakProvider.get_backend('scaleway_*') now returns ArvakBackend "
+            "(native HAL-backed). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import requests as _requests
         self._requests = _requests
 

--- a/crates/arvak-python/python/arvak/integrations/qrisp/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qrisp/backend.py
@@ -7,7 +7,8 @@ Supported backends:
   - 'sim'      : Arvak's built-in Rust statevector simulator (no credentials)
   - 'iqm'      : IQM Resonance QPU via the native arvak-adapter-iqm
                  (requires IQM_TOKEN; no qiskit-iqm dependency)
-  - 'scaleway' : Scaleway QaaS (IQM QPU) via REST API (requires SCALEWAY credentials)
+  - 'scaleway' : Scaleway QaaS (IQM QPU) via the native arvak-adapter-scaleway
+                 (requires SCALEWAY credentials; no requests-loop in Python)
 """
 
 import os
@@ -29,9 +30,6 @@ SCALEWAY_PLATFORMS = {
     "QPU-GARNET-20PQ": {"qubits": 20, "topology": "crystal"},
     "QPU-EMERALD-54PQ": {"qubits": 54, "topology": "crystal"},
 }
-
-# Scaleway QaaS REST endpoint
-_SCALEWAY_API_URL = "https://api.scaleway.com/qaas/v1alpha1"
 
 
 class ArvakBackendClient:
@@ -191,7 +189,12 @@ class ArvakBackendClient:
         return dict(result.counts)
 
     def _run_scaleway(self, arvak_circuit, shots: int, **options) -> dict[str, int]:
-        """Compile with Arvak and submit to Scaleway QaaS (IQM QPU).
+        """Compile with Arvak and submit to Scaleway QaaS via the native adapter.
+
+        Phase 3: no longer makes direct HTTP calls with `requests`.
+        Submission goes through the native Rust ``arvak-adapter-scaleway``
+        (REST against ``api.scaleway.com/qaas``) reached via
+        ``arvak.backend_for("scaleway_<machine>")``.
 
         Requires:
           - ``SCALEWAY_SECRET_KEY``  env var
@@ -199,25 +202,21 @@ class ArvakBackendClient:
           - ``SCALEWAY_SESSION_ID``  env var (pre-created QaaS session)
           - ``SCALEWAY_PLATFORM``    env var (optional; default: QPU-GARNET-20PQ)
 
-        The circuit is compiled by Arvak for the selected IQM topology and
-        submitted as QASM3 to the Scaleway QaaS REST API.
+        The compile pass (PRX+CZ basis, topology-aware routing) runs
+        unchanged on the Arvak side; only the submission path moved to
+        Rust.
         """
         import arvak
-        import json
 
-        secret_key = os.environ.get('SCALEWAY_SECRET_KEY')
-        project_id = os.environ.get('SCALEWAY_PROJECT_ID')
-        session_id = os.environ.get('SCALEWAY_SESSION_ID')
-
-        if not secret_key:
-            raise RuntimeError("SCALEWAY_SECRET_KEY environment variable not set.")
-        if not project_id:
-            raise RuntimeError("SCALEWAY_PROJECT_ID environment variable not set.")
-        if not session_id:
-            raise RuntimeError(
-                "SCALEWAY_SESSION_ID environment variable not set.\n"
-                "Create a session at console.scaleway.com > Quantum Computing > Sessions."
-            )
+        # Validate env vars early with clear messages (the native adapter
+        # also checks but produces less context-rich errors at PyO3 layer).
+        for var in ("SCALEWAY_SECRET_KEY", "SCALEWAY_PROJECT_ID", "SCALEWAY_SESSION_ID"):
+            if not os.environ.get(var):
+                hint = ""
+                if var == "SCALEWAY_SESSION_ID":
+                    hint = ("\nCreate a session at "
+                            "console.scaleway.com > Quantum Computing > Sessions.")
+                raise RuntimeError(f"{var} environment variable not set.{hint}")
 
         platform = options.get(
             'platform',
@@ -227,7 +226,7 @@ class ArvakBackendClient:
         num_qubits = plat_info['qubits']
         topology = plat_info['topology']
 
-        # Compile circuit with Arvak for the target IQM topology
+        # Compile circuit with Arvak for the target IQM topology — unchanged.
         if topology == 'star':
             coupling = arvak.CouplingMap.star(num_qubits)
         else:
@@ -241,102 +240,21 @@ class ArvakBackendClient:
             optimization_level=options.get('optimization_level', 1),
         )
 
-        # Export compiled circuit to QASM3 with stdgates include for Scaleway
         qasm_str = arvak.to_qasm(compiled)
-        qasm_str = qasm_str.replace(
-            "OPENQASM 3.0;",
-            'OPENQASM 3.0;\ninclude "stdgates.inc";',
-            1,
-        )
 
-        # Submit to Scaleway QaaS REST API
-        try:
-            import requests
-        except ImportError as exc:
-            raise ImportError(
-                "Scaleway backend requires the 'requests' package.\n"
-                "Install with: pip install requests"
-            ) from exc
+        # Map platform string to the arvak.backend_for registry name.
+        # The registry branch translates back to the QPU-* platform string
+        # for the native adapter — single mapping point.
+        machine = {
+            "QPU-GARNET-20PQ": "garnet",
+            "QPU-SIRIUS-24PQ": "sirius",
+            "QPU-EMERALD-54PQ": "emerald",
+        }.get(platform, "garnet")
 
-        headers = {
-            "X-Auth-Token": secret_key,
-            "Content-Type": "application/json",
-        }
-
-        # Create a job in the existing session
-        body = {
-            "session_id": session_id,
-            "circuit": {
-                "type": "QASM",
-                "content": qasm_str,
-            },
-            "shots": shots,
-        }
-
-        resp = requests.post(
-            f"{_SCALEWAY_API_URL}/jobs",
-            headers=headers,
-            json=body,
-            timeout=60,
-        )
-        if not resp.ok:
-            raise RuntimeError(
-                f"Scaleway job submission failed ({resp.status_code}): {resp.text}"
-            )
-
-        job_data = resp.json()
-        job_id = job_data.get("id")
-
-        # Poll for completion
-        import time
-        timeout = options.get('timeout', 600)
-        poll_interval = options.get('poll_interval', 5)
-        start = time.time()
-
-        while True:
-            elapsed = time.time() - start
-            if elapsed > timeout:
-                raise RuntimeError(
-                    f"Scaleway job {job_id} timed out after {timeout}s"
-                )
-
-            resp = requests.get(
-                f"{_SCALEWAY_API_URL}/jobs/{job_id}",
-                headers=headers,
-                timeout=30,
-            )
-            if not resp.ok:
-                raise RuntimeError(f"Failed to poll job status: {resp.text}")
-
-            data = resp.json()
-            status = data.get("status", "").upper()
-
-            if status in ("COMPLETED", "SUCCEEDED", "DONE"):
-                break
-            elif status in ("FAILED", "ERROR", "CANCELLED"):
-                raise RuntimeError(
-                    f"Scaleway job {job_id} {status.lower()}: "
-                    f"{data.get('error', {}).get('message', 'unknown error')}"
-                )
-
-            time.sleep(poll_interval)
-
-        # Fetch results
-        resp = requests.get(
-            f"{_SCALEWAY_API_URL}/jobs/{job_id}/results",
-            headers=headers,
-            timeout=60,
-        )
-        if not resp.ok:
-            raise RuntimeError(f"Failed to fetch Scaleway results: {resp.text}")
-
-        results_data = resp.json()
-        counts: dict[str, int] = {}
-        for result in results_data.get("results", []):
-            for bitstring, count in result.get("counts", {}).items():
-                counts[bitstring] = counts.get(bitstring, 0) + count
-
-        return counts
+        backend = arvak.backend_for(f"scaleway_{machine}")
+        handle = backend.submit(qasm_str, shots)
+        result = handle.result()  # blocks until done
+        return dict(result.counts)
 
     def __repr__(self) -> str:
         return f"<ArvakBackendClient('{self.name}')>"

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -724,6 +724,54 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // Scaleway QaaS — IQM hardware (Garnet/Sirius/Emerald) hosted by
+        // Scaleway, accessed via their REST API. Requires three env vars:
+        // SCALEWAY_SECRET_KEY, SCALEWAY_PROJECT_ID, SCALEWAY_SESSION_ID
+        // (the session must be pre-created in the Scaleway console).
+        n if n.starts_with("scaleway_") => {
+            #[cfg(feature = "adapter-scaleway")]
+            {
+                let machine = &n["scaleway_".len()..];
+                let platform = match machine {
+                    "garnet" => "QPU-GARNET-20PQ",
+                    "sirius" => "QPU-SIRIUS-24PQ",
+                    "emerald" => "QPU-EMERALD-54PQ",
+                    _ => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown Scaleway machine: {n} \
+                             (known: scaleway_garnet, scaleway_sirius, scaleway_emerald)"
+                        )));
+                    }
+                };
+                let secret_key = std::env::var("SCALEWAY_SECRET_KEY").map_err(|_| {
+                    HalError::Configuration(
+                        "SCALEWAY_SECRET_KEY not set — get it from \
+                         console.scaleway.com → API keys"
+                            .into(),
+                    )
+                })?;
+                let project_id = std::env::var("SCALEWAY_PROJECT_ID")
+                    .map_err(|_| HalError::Configuration("SCALEWAY_PROJECT_ID not set".into()))?;
+                let session_id = std::env::var("SCALEWAY_SESSION_ID").map_err(|_| {
+                    HalError::Configuration(
+                        "SCALEWAY_SESSION_ID not set — create a session at \
+                         console.scaleway.com → Quantum Computing → Sessions"
+                            .into(),
+                    )
+                })?;
+                let backend = arvak_adapter_scaleway::ScalewayBackend::with_credentials(
+                    secret_key, project_id, session_id, platform,
+                )
+                .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-scaleway"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "Scaleway adapter not compiled in for backend {n} (enable 'adapter-scaleway' feature)"
+                )))
+            }
+        }
         n if n.starts_with("iqm_") => {
             #[cfg(feature = "adapter-iqm")]
             {
@@ -774,6 +822,12 @@ fn known_backends() -> Vec<String> {
         v.push("iqm_helmi".into());
         // LRZ-hosted IQM machines — OIDC auth; users append machine name
         // (e.g. iqm_lrz_<machine>). The bare "iqm_lrz_" form is invalid.
+    }
+    #[cfg(feature = "adapter-scaleway")]
+    {
+        v.push("scaleway_garnet".into());
+        v.push("scaleway_sirius".into());
+        v.push("scaleway_emerald".into());
     }
     v
 }


### PR DESCRIPTION
## Summary

`ArvakProvider.get_backend('scaleway_*')` (qiskit) and
`ArvakBackendClient('scaleway')` (qrisp) now both route through the
native Rust `arvak-adapter-scaleway` via PyO3. Removes the in-Python
`requests` HTTP loop that both integrations used to talk to
`api.scaleway.com` directly.

Same shape as Phase 2a (IQM Cloud Resonance): user-facing API
unchanged, implementation underneath swaps from "Python requests
pipeline" to "native adapter via PyO3".

## What changed

| Component | Change |
|---|---|
| **Cargo feature** | New `adapter-scaleway`, in `default` |
| **`make_backend()`** | Prefix branch for `scaleway_<machine>` (garnet/sirius/emerald) → `ScalewayBackend::with_credentials()` with three env vars |
| **qiskit `ArvakProvider`** | `scaleway_*` lookups now return `ArvakBackend` (native PyO3 wrapper) instead of `ArvakScalewayBackend` (legacy Python class) |
| **`ArvakScalewayBackend`** | Importable, emits `DeprecationWarning` at construction |
| **qrisp `_run_scaleway`** | No more `requests.post`/`get` loop. After compile pass, QASM3 goes to `arvak.backend_for(f"scaleway_{machine}").submit(...)` then `handle.result()` |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-scaleway --lib`: 25 passed (no regression)
- [x] 52/52 pre-existing qiskit + circuit tests pass
- [x] 13 Phase-1.5, 10 Phase-2a, 10 Phase-2b smoke tests all pass (no regression)
- [x] 11 new Phase-3 smoke tests:
  - registry lists scaleway_garnet/sirius/emerald
  - unknown scaleway machine rejected
  - clear errors for each missing env var
  - per-platform qubit counts correct (20/16/54)
  - ArvakProvider routes to ArvakBackend
  - legacy class emits DeprecationWarning
  - qrisp `_run_scaleway` source-inspection confirms `arvak.backend_for` usage
  - sim + iqm_garnet unchanged
- [ ] CI: this PR's run

## No live Scaleway calls in tests

The user did not authorise live Scaleway calls for this session, and
the project memory rule requires explicit per-session permission for
real hardware. All assertions are static / metadata / error-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)