### PR TITLE
feat(python): RFC-0001 Phase 4 — native IBM Cloud adapter via PyO3 (US-East + EU Frankfurt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
 name = "arvak-python"
 version = "1.9.5"
 dependencies = [
+ "arvak-adapter-ibm",
  "arvak-adapter-iqm",
  "arvak-adapter-scaleway",
  "arvak-adapter-sim",

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,10 +11,11 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm", "adapter-scaleway"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
 adapter-scaleway = ["arvak-adapter-scaleway"]
+adapter-ibm = ["arvak-adapter-ibm"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -25,6 +26,7 @@ arvak-hal = { workspace = true }
 arvak-adapter-sim = { workspace = true, optional = true }
 arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
 arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
+arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -273,15 +273,21 @@ class ArvakProvider:
             # See docs/RFC/0001-native-backend-unification.md.
             self._backends['sim'] = ArvakBackend(provider=self, backend_name='sim')
 
-        # Lazily create IBM backends on demand
+        # Lazily create IBM backends on demand — Phase 4: native arvak-adapter-ibm
+        # via PyO3. Construction triggers an HTTP call to fetch real backend
+        # topology / qubit count from IBM Cloud (no more 127-qubit fallback).
+        # See RFC-0001 Phase 4.
         if name and name in self._IBM_BACKENDS and name not in self._backends:
             try:
-                self._backends[name] = ArvakIBMBackend(provider=self, target=name)
-            except (ValueError, ImportError) as e:
-                # Credentials not set or requests not available
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
+                )
+            except (ValueError, RuntimeError, ConnectionError, PermissionError) as e:
                 raise ValueError(
                     f"Cannot connect to {name}: {e}. "
-                    f"Set IBM_API_KEY and IBM_SERVICE_CRN environment variables."
+                    f"Set IBM_API_KEY and IBM_SERVICE_CRN environment variables. "
+                    f"For EU backends (brussels/strasbourg/aachen), also set "
+                    f"IBM_SERVICE_CRN_EU."
                 ) from e
 
         # Lazily create Scaleway backends — Phase 3: native arvak-adapter-scaleway
@@ -598,6 +604,17 @@ class ArvakSimulatorBackend:
 class ArvakIBMBackend:
     """Arvak IBM Quantum backend with Qiskit-compatible interface.
 
+    .. deprecated:: 2.3
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('ibm_torino')`` now returns the
+        native-HAL-backed class automatically (Phase 4). Direct
+        instantiation of this class still works but will be removed in
+        a future release. The native path replaces the in-Python
+        ``requests`` HTTP loop with ``arvak-adapter-ibm`` (Rust REST
+        client) reached via PyO3, and fetches real backend topology
+        from the IBM Cloud API at construction (no more 127-qubit
+        fallback).
+
     Compiles circuits with Arvak's Rust compiler and submits them to
     IBM Quantum hardware via the IBM Cloud REST API.
 
@@ -609,6 +626,15 @@ class ArvakIBMBackend:
     _BACKEND_INFO_TTL: int = 300
 
     def __init__(self, provider: ArvakProvider, target: str = 'ibm_torino'):
+        import warnings
+        warnings.warn(
+            "ArvakIBMBackend is deprecated; "
+            "ArvakProvider.get_backend('ibm_*') now returns ArvakBackend "
+            "(native HAL-backed, fetches real topology from IBM Cloud). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import requests as _requests
         self._requests = _requests
 

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -724,6 +724,68 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // IBM Quantum (Cloud API). Modern path uses IBM_API_KEY + a service
+        // CRN. EU-hosted backends (brussels, strasbourg, aachen) check
+        // IBM_SERVICE_CRN_EU first, with fallback to IBM_SERVICE_CRN — matches
+        // the legacy ArvakIBMBackend behaviour. US-East backends use
+        // IBM_SERVICE_CRN directly. The native adapter parses the CRN to
+        // pick the correct region endpoint.
+        n if n.starts_with("ibm_") => {
+            #[cfg(feature = "adapter-ibm")]
+            {
+                const EU_BACKENDS: &[&str] = &["ibm_brussels", "ibm_strasbourg", "ibm_aachen"];
+                let is_eu = EU_BACKENDS.contains(&n);
+
+                // Sanity check: we want IBM_API_KEY to be set before going
+                // further so the error message points at the missing key
+                // rather than an IbmError::MissingServiceCrn surfaced from
+                // deep inside connect().
+                std::env::var("IBM_API_KEY").map_err(|_| {
+                    HalError::Configuration(
+                        "IBM_API_KEY not set — required for IBM Cloud Quantum API. \
+                         Get it from cloud.ibm.com → API keys."
+                            .into(),
+                    )
+                })?;
+
+                // EU path: prefer IBM_SERVICE_CRN_EU, fall back to IBM_SERVICE_CRN.
+                // Adapter reads IBM_SERVICE_CRN directly, so we shim the EU CRN
+                // through it when present.
+                if is_eu && let Ok(eu_crn) = std::env::var("IBM_SERVICE_CRN_EU") {
+                    // SAFETY: setting env var to redirect the adapter's read.
+                    // Single-threaded at this point in the registry path.
+                    unsafe {
+                        std::env::set_var("IBM_SERVICE_CRN", &eu_crn);
+                    }
+                }
+
+                if std::env::var("IBM_SERVICE_CRN").is_err() {
+                    let hint = if is_eu {
+                        "IBM_SERVICE_CRN_EU or IBM_SERVICE_CRN not set — required for \
+                         EU-hosted IBM backends (Frankfurt region)."
+                    } else {
+                        "IBM_SERVICE_CRN not set — required for IBM Cloud Quantum API. \
+                         Format: crn:v1:bluemix:public:quantum-computing:<region>:..."
+                    };
+                    return Err(HalError::Configuration(hint.into()));
+                }
+
+                // IbmBackend::connect() is async (fetches real topology /
+                // qubit count from the Cloud API). Block on it via the
+                // shared runtime.
+                let target = n.to_string();
+                let backend = runtime()
+                    .block_on(arvak_adapter_ibm::IbmBackend::connect(target))
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-ibm"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "IBM adapter not compiled in for backend {n} (enable 'adapter-ibm' feature)"
+                )))
+            }
+        }
         // Scaleway QaaS — IQM hardware (Garnet/Sirius/Emerald) hosted by
         // Scaleway, accessed via their REST API. Requires three env vars:
         // SCALEWAY_SECRET_KEY, SCALEWAY_PROJECT_ID, SCALEWAY_SESSION_ID
@@ -828,6 +890,22 @@ fn known_backends() -> Vec<String> {
         v.push("scaleway_garnet".into());
         v.push("scaleway_sirius".into());
         v.push("scaleway_emerald".into());
+    }
+    #[cfg(feature = "adapter-ibm")]
+    {
+        // US-East
+        v.push("ibm_torino".into());
+        v.push("ibm_fez".into());
+        v.push("ibm_marrakesh".into());
+        v.push("ibm_brisbane".into());
+        v.push("ibm_kyoto".into());
+        v.push("ibm_osaka".into());
+        v.push("ibm_sherbrooke".into());
+        v.push("ibm_nazca".into());
+        // EU (Frankfurt)
+        v.push("ibm_brussels".into());
+        v.push("ibm_strasbourg".into());
+        v.push("ibm_aachen".into());
     }
     v
 }


### PR DESCRIPTION
## Summary

`ArvakProvider.get_backend('ibm_*')` now routes through the native
Rust `arvak-adapter-ibm` via PyO3. Replaces the in-Python `requests`
HTTP loop in `ArvakIBMBackend`.

Both US-East (`IBM_SERVICE_CRN`) and EU Frankfurt (`IBM_SERVICE_CRN_EU`)
regions are supported with the same env-var conventions the legacy
class used. The native adapter eagerly fetches real backend topology
and qubit count from the IBM Cloud API on construction — no more
127-qubit `conservative fallback`.

qrisp has no IBM bypass (its `_HARDWARE_BACKENDS` is only `{iqm,
scaleway}`), so no cross-integration sweep — RFC §Phase 4 impact map
shows `n/a` for cirq/pennylane/qrisp on IBM.

## Hidden-behaviour audit (RFC §Risks #2)

The legacy class had two hardcoded values worth flagging:

1. **`max_qubits = 127  # conservative fallback`** — used when live
   backend-info HTTP fetch failed. Native adapter avoids: `connect()`
   fetches real `num_qubits` at construction, no silent fallback.
2. **27-qubit hardcoded heavy-hex topology** — was a test fixture in
   `_BACKEND_INFO_CACHE` for `ibm_torino`. Native adapter queries
   IBM Cloud for the real topology.

Both are improvements, not regressions. Documented in commit for
Phase-7 cleanup.

## What changed

| Component | Change |
|---|---|
| **Cargo feature** | New `adapter-ibm`, in `default` |
| **`make_backend()`** | Prefix branch for `ibm_*` (8 US + 3 EU). EU backends shim `IBM_SERVICE_CRN_EU` into the adapter's `IBM_SERVICE_CRN` read. Calls async `IbmBackend::connect()` via shared tokio runtime |
| **`known_backends()`** | Lists all 11 IBM machines |
| **qiskit `ArvakProvider`** | `ibm_*` lookups return `ArvakBackend` (native) instead of `ArvakIBMBackend` (legacy) |
| **`ArvakIBMBackend`** | Importable, emits `DeprecationWarning` at construction |
| **qrisp** | No change — has no IBM bypass to fix |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-ibm --lib`: 42 passed (no regression)
- [x] 52/52 pre-existing qiskit + circuit tests pass
- [x] 13 Phase-1.5, 10 Phase-2a, 10 Phase-2b, 11 Phase-3 smoke tests: all pass
- [x] 11 new Phase-4 smoke tests cover:
  - registry lists 11 IBM backends (8 US + 3 EU)
  - clear error for missing `IBM_API_KEY` / `IBM_SERVICE_CRN`
  - EU-specific error mentions `IBM_SERVICE_CRN_EU`
  - EU CRN env-var override accepted (passes validation)
  - `ArvakProvider` routes via `ArvakBackend`
  - legacy class emits `DeprecationWarning`
  - qrisp confirmed no IBM bypass (nothing else to fix)
  - sim / iqm_garnet / scaleway_garnet unchanged
- [ ] CI: this PR's run

## No live IBM Cloud calls in tests

Per the project memory rule. Construction with dummy credentials
would hit IBM Cloud auth and fail — only env-var error paths,
deprecation, and routing assertions covered.

## Out of scope

- **YAQS evaluation** for IBM noise modelling — opted to skip per
  user "weiter" (RFC gate is explicit non-blocking).
- **Token-mode fallback** (`IBM_QUANTUM_TOKEN` without API key) —
  native adapter supports it via `IbmBackend::with_target()` but
  not wired in registry; can be added later if anyone uses the
  legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)