### PR TITLE
feat(python): RFC-0001 Phase 5 — native Quantinuum (ionshuttler eval: skip)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ version = "1.9.5"
 dependencies = [
  "arvak-adapter-ibm",
  "arvak-adapter-iqm",
+ "arvak-adapter-quantinuum",
  "arvak-adapter-scaleway",
  "arvak-adapter-sim",
  "arvak-compile",

--- a/adapters/arvak-adapter-quantinuum/src/backend.rs
+++ b/adapters/arvak-adapter-quantinuum/src/backend.rs
@@ -190,8 +190,27 @@ impl QuantinuumBackend {
     }
 }
 
+/// Per-target qubit counts for known Quantinuum machines.
+///
+/// Matches the legacy `ArvakQuantinuumBackend._MACHINE_QUBITS` dict so the
+/// capabilities surface remains stable when the Python integration switches
+/// to the native adapter. Falls back to the caller-supplied default for
+/// unknown targets so user-defined machine names still work.
+///
+/// Note: the H1/H2 lines have well-known stable qubit counts (Quantinuum
+/// hasn't changed these in years). The TTL-cached `machine_info` API
+/// query overrides this at runtime once available.
+fn qubits_for_target(target: &str, default: u32) -> u32 {
+    match target {
+        "H2-1" | "H2-1E" | "H2-1LE" => 32,
+        "H1-1" | "H1-1E" => 20,
+        _ => default,
+    }
+}
+
 /// Build `Capabilities` for a Quantinuum machine from its name.
-fn build_capabilities(target: &str, num_qubits: u32) -> Capabilities {
+fn build_capabilities(target: &str, num_qubits_default: u32) -> Capabilities {
+    let num_qubits = qubits_for_target(target, num_qubits_default);
     let is_simulator = target.ends_with('E') || target.ends_with("LE");
     Capabilities::quantinuum(target, num_qubits).with_simulator(is_simulator)
 }

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,11 +11,12 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
 adapter-scaleway = ["arvak-adapter-scaleway"]
 adapter-ibm = ["arvak-adapter-ibm"]
+adapter-quantinuum = ["arvak-adapter-quantinuum"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -27,6 +28,7 @@ arvak-adapter-sim = { workspace = true, optional = true }
 arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
 arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
 arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
+arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -319,14 +319,19 @@ class ArvakProvider:
                     f"Set IQM_TOKEN environment variable (from resonance.meetiqm.com)."
                 ) from e
 
-        # Lazily create Quantinuum backends on demand
+        # Lazily create Quantinuum backends — Phase 5: native
+        # arvak-adapter-quantinuum via PyO3. The registry maps the
+        # arvak-side names (quantinuum_h2 / _h1_emulator / _h2_emulator)
+        # to Quantinuum machine identifiers (H2-1 / H1-1E / H2-1E).
+        # ionshuttler integration evaluated and skipped per RFC §Phase 5
+        # gate eval on 2026-06-25 — Quantinuum's commercial pipeline
+        # owns shuttle scheduling, not user-controllable via REST.
         if name and name in self._QUANTINUUM_BACKENDS and name not in self._backends:
             try:
-                device = self._QUANTINUUM_DEVICE_MAP[name]
-                self._backends[name] = ArvakQuantinuumBackend(
-                    provider=self, device_name=device,
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
                 )
-            except (ValueError, ImportError) as e:
+            except (ValueError, RuntimeError, ConnectionError, PermissionError) as e:
                 raise ValueError(
                     f"Cannot connect to {name}: {e}. "
                     f"Set QUANTINUUM_EMAIL and QUANTINUUM_PASSWORD environment variables."
@@ -1928,6 +1933,15 @@ class ArvakScalewayJob:
 class ArvakQuantinuumBackend:
     """Arvak Quantinuum backend — submits directly to Quantinuum's REST API.
 
+    .. deprecated:: 2.4
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('quantinuum_h2')`` now returns the
+        native-HAL-backed class automatically (Phase 5). Direct
+        instantiation of this class still works but will be removed in
+        a future release. The native path replaces the in-Python
+        ``requests`` HTTP loop with ``arvak-adapter-quantinuum`` (Rust
+        REST client) reached via PyO3.
+
     Accepts Qiskit circuits, converts them to QASM 2.0 (using qiskit.qasm2),
     and submits to Quantinuum's cloud API.  The Quantinuum cloud compiles
     circuits to its native ion-trap gate set (ZZMax/ZZPhase/U1q/Rz) internally.
@@ -1949,6 +1963,15 @@ class ArvakQuantinuumBackend:
     _MACHINE_INFO_TTL: int = 300
 
     def __init__(self, provider: ArvakProvider, device_name: str = 'H2-1LE'):
+        import warnings
+        warnings.warn(
+            "ArvakQuantinuumBackend is deprecated; "
+            "ArvakProvider.get_backend('quantinuum_*') now returns ArvakBackend "
+            "(native HAL-backed). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import requests as _requests
         self._requests = _requests
 

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -724,6 +724,59 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // Quantinuum H1/H2 ion-trap systems (real hardware + emulators).
+        // Auth via QUANTINUUM_EMAIL + QUANTINUUM_PASSWORD env vars.
+        //
+        // Registry name → Quantinuum machine identifier:
+        //   quantinuum_h2           → H2-1   (real H2 hardware)
+        //   quantinuum_h2_emulator  → H2-1E  (cloud emulator)
+        //   quantinuum_h1_emulator  → H1-1E  (cloud emulator)
+        //   (the local noiseless emulator H2-1LE is the adapter default)
+        //
+        // RFC §Phase 5 gate: evaluated MQT ionshuttler on 2026-06-25,
+        // decided to skip. ionshuttler is a generic QCCD research tool —
+        // Quantinuum's commercial pipeline handles shuttling internally
+        // and doesn't expose shuttle-schedule input via REST. Not
+        // useful in our thin-adapter shape.
+        n if n.starts_with("quantinuum_") => {
+            #[cfg(feature = "adapter-quantinuum")]
+            {
+                let machine = match n {
+                    "quantinuum_h2" => "H2-1",
+                    "quantinuum_h2_emulator" => "H2-1E",
+                    "quantinuum_h1_emulator" => "H1-1E",
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown Quantinuum backend: {other} \
+                             (known: quantinuum_h2, quantinuum_h2_emulator, quantinuum_h1_emulator)"
+                        )));
+                    }
+                };
+                // Pre-validate env vars for clearer error messages than the
+                // adapter's bare MissingEmail / MissingPassword variants.
+                std::env::var("QUANTINUUM_EMAIL").map_err(|_| {
+                    HalError::Configuration(
+                        "QUANTINUUM_EMAIL not set — required for Quantinuum API auth. \
+                         Sign up at quantinuum.com."
+                            .into(),
+                    )
+                })?;
+                std::env::var("QUANTINUUM_PASSWORD").map_err(|_| {
+                    HalError::Configuration(
+                        "QUANTINUUM_PASSWORD not set — required for Quantinuum API auth.".into(),
+                    )
+                })?;
+                let backend = arvak_adapter_quantinuum::QuantinuumBackend::with_target(machine)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-quantinuum"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "Quantinuum adapter not compiled in for backend {n} (enable 'adapter-quantinuum' feature)"
+                )))
+            }
+        }
         // IBM Quantum (Cloud API). Modern path uses IBM_API_KEY + a service
         // CRN. EU-hosted backends (brussels, strasbourg, aachen) check
         // IBM_SERVICE_CRN_EU first, with fallback to IBM_SERVICE_CRN — matches
@@ -890,6 +943,12 @@ fn known_backends() -> Vec<String> {
         v.push("scaleway_garnet".into());
         v.push("scaleway_sirius".into());
         v.push("scaleway_emerald".into());
+    }
+    #[cfg(feature = "adapter-quantinuum")]
+    {
+        v.push("quantinuum_h2".into());
+        v.push("quantinuum_h2_emulator".into());
+        v.push("quantinuum_h1_emulator".into());
     }
     #[cfg(feature = "adapter-ibm")]
     {


### PR DESCRIPTION
## Summary

`ArvakProvider.get_backend('quantinuum_*')` now routes through the
native Rust `arvak-adapter-quantinuum` via PyO3. Replaces the in-Python
`requests` loop in `ArvakQuantinuumBackend`.

| Registry name | Machine ID | Qubits | Type |
|---|---|---|---|
| `quantinuum_h2` | H2-1 | 32 | real hardware |
| `quantinuum_h2_emulator` | H2-1E | 32 | cloud emulator |
| `quantinuum_h1_emulator` | H1-1E | 20 | cloud emulator |

qrisp has no Quantinuum bypass (only `iqm` + `scaleway`), so no
cross-integration sweep needed (RFC §Phase 5 impact map: `n/a` across
cirq/pennylane/qrisp).

## RFC §Phase 5 ionshuttler gate

Evaluated [MQT IonShuttler](https://github.com/munich-quantum-toolkit/ionshuttler)
on 2026-06-25 per the gate. **Decision: skip.** Reasoning recorded in
the commit message and reproduced here:

- Targets generic QCCD research architectures, takes JSON device +
  algorithm specs, produces physical ion-movement schedules.
- Does **not** target Quantinuum H1/H2 specifically — no mention in
  README, docs, or release notes.
- Quantinuum's commercial pipeline owns shuttle scheduling — users
  submit QASM, Quantinuum's compiler handles ion movements.
  ionshuttler-generated schedules cannot be submitted to Quantinuum.
- Integration would yield no real-job improvement, only academic
  "if-we-had-shuttle-control" analyses.

Reconsider if/when:
1. MQV/LRZ research collaboration on QCCD-aware compilation
2. Alsvid grows its own ion-trap simulation
3. A QCCD vendor exposes shuttle-schedule input via API

## Hidden-behaviour audit (RFC §Risks #2)

Legacy `ArvakQuantinuumBackend._MACHINE_QUBITS` had per-target qubit
counts (32 for H2-family, 20 for H1-family). Native adapter previously
hardcoded 32 for all targets — same regression risk as IQM Phase 2a.

Fixed in this PR: added `qubits_for_target()` helper that returns
correct counts per machine name. TTL-cached `machine_info` HTTP query
overrides these defaults at runtime once available.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-quantinuum --lib`: 22 passed
- [x] 52/52 pre-existing qiskit + circuit tests pass
- [x] All earlier-phase smoke tests still pass (Phase-1.5/2a/2b/3/4)
- [x] 10 new Phase-5 smoke tests:
  - registry lists three Quantinuum targets
  - unknown target rejected
  - clear errors for missing env vars
  - per-target qubit counts (32/32/20) correct
  - simulator flags correct (H2-1E/H1-1E vs H2-1)
  - `ArvakProvider` routes via `ArvakBackend`
  - legacy class emits `DeprecationWarning`
  - qrisp confirmed no bypass
- [ ] CI: this PR's run

## No live Quantinuum calls

Per the project memory rule. All assertions are static / metadata /
error-path. Real cloud auth would burn paid credit and is out of
scope without explicit per-session permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)