### PR TITLE
feat(python): RFC-0001 Phase 6 — native AQT + IonQ adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,9 @@ dependencies = [
 name = "arvak-python"
 version = "1.9.5"
 dependencies = [
+ "arvak-adapter-aqt",
  "arvak-adapter-ibm",
+ "arvak-adapter-ionq",
  "arvak-adapter-iqm",
  "arvak-adapter-quantinuum",
  "arvak-adapter-scaleway",

--- a/adapters/arvak-adapter-ionq/src/backend.rs
+++ b/adapters/arvak-adapter-ionq/src/backend.rs
@@ -24,11 +24,27 @@ use crate::error::{IonQError, IonQResult};
 /// IonQ simulator backend name.
 pub const SIMULATOR: &str = "simulator";
 
-/// Simulator qubit limit.
+/// Simulator qubit limit (free-tier).
 const SIMULATOR_MAX_QUBITS: u32 = 29;
 
-/// QPU qubit limit (Aria/Forte — 25 algorithmic qubits).
+/// Aria QPU qubit limit (algorithmic qubits, Aria-1 and Aria-2).
 const QPU_MAX_QUBITS: u32 = 25;
+
+/// Per-target qubit count for known IonQ backends.
+///
+/// Mirrors the legacy `ArvakIonQBackend._BACKEND_QUBITS` dict so the
+/// capabilities surface stays stable when the Python integration switches
+/// to the native adapter. Forte-1 is 36 qubits — explicitly distinct from
+/// Aria's 25. Falls back to [`QPU_MAX_QUBITS`] for unknown QPU names so
+/// user-supplied targets still build a capability.
+fn qubits_for_backend(backend_name: &str) -> u32 {
+    match backend_name {
+        SIMULATOR => SIMULATOR_MAX_QUBITS,
+        "qpu.aria-1" | "qpu.aria-2" => 25,
+        "qpu.forte-1" => 36,
+        _ => QPU_MAX_QUBITS,
+    }
+}
 
 /// Maximum number of cached job entries before evicting terminal-state entries.
 const MAX_CACHED_JOBS: usize = 10_000;
@@ -104,11 +120,7 @@ impl IonQBackend {
         let backend_name = backend_name.into();
         let name = format!("ionq_{}", backend_name.replace('.', "_"));
 
-        let max_qubits = if backend_name == SIMULATOR {
-            SIMULATOR_MAX_QUBITS
-        } else {
-            QPU_MAX_QUBITS
-        };
+        let max_qubits = qubits_for_backend(&backend_name);
         let capabilities = build_capabilities(&backend_name, max_qubits);
 
         Ok(Self {
@@ -130,11 +142,7 @@ impl IonQBackend {
         let backend_name = backend_name.into();
         let name = format!("ionq_{}", backend_name.replace('.', "_"));
 
-        let max_qubits = if backend_name == SIMULATOR {
-            SIMULATOR_MAX_QUBITS
-        } else {
-            QPU_MAX_QUBITS
-        };
+        let max_qubits = qubits_for_backend(&backend_name);
         let capabilities = build_capabilities(&backend_name, max_qubits);
 
         Ok(Self {

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,12 +11,14 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum", "adapter-aqt", "adapter-ionq"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
 adapter-scaleway = ["arvak-adapter-scaleway"]
 adapter-ibm = ["arvak-adapter-ibm"]
 adapter-quantinuum = ["arvak-adapter-quantinuum"]
+adapter-aqt = ["arvak-adapter-aqt"]
+adapter-ionq = ["arvak-adapter-ionq"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -29,6 +31,8 @@ arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true
 arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
 arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
 arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
+arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
+arvak-adapter-ionq = { path = "../../adapters/arvak-adapter-ionq", optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
+++ b/crates/arvak-python/python/arvak/integrations/qiskit/backend.py
@@ -337,21 +337,27 @@ class ArvakProvider:
                     f"Set QUANTINUUM_EMAIL and QUANTINUUM_PASSWORD environment variables."
                 ) from e
 
-        # Lazily create AQT backends on demand
+        # Lazily create AQT backends on demand — Phase 6: native
+        # arvak-adapter-aqt via PyO3.
         if name and name in self._AQT_BACKENDS and name not in self._backends:
-            workspace, resource = self._AQT_RESOURCE_MAP[name]
-            self._backends[name] = ArvakAQTBackend(
-                provider=self, workspace=workspace, resource=resource,
-            )
+            try:
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
+                )
+            except (ValueError, RuntimeError, ConnectionError, PermissionError) as e:
+                raise ValueError(
+                    f"Cannot connect to {name}: {e}. "
+                    f"Set AQT_TOKEN environment variable."
+                ) from e
 
-        # Lazily create IonQ backends on demand
+        # Lazily create IonQ backends on demand — Phase 6: native
+        # arvak-adapter-ionq via PyO3.
         if name and name in self._IONQ_BACKENDS and name not in self._backends:
             try:
-                device = self._IONQ_DEVICE_MAP[name]
-                self._backends[name] = ArvakIonQBackend(
-                    provider=self, backend_name=device,
+                self._backends[name] = ArvakBackend(
+                    provider=self, backend_name=name,
                 )
-            except (ValueError, ImportError) as e:
+            except (ValueError, RuntimeError, ConnectionError, PermissionError) as e:
                 raise ValueError(
                     f"Cannot connect to {name}: {e}. "
                     f"Set IONQ_API_KEY environment variable."
@@ -2737,6 +2743,14 @@ def _iqm_postprocess_qasm(qasm: str) -> str:
 class ArvakAQTBackend:
     """Arvak AQT backend — submits directly to AQT's Arnica REST API.
 
+    .. deprecated:: 2.5
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('aqt_*')`` now returns the native-HAL-
+        backed class automatically (Phase 6). Direct instantiation of this
+        class still works but will be removed in a future release. The
+        native path replaces the in-Python ``requests`` HTTP loop with
+        ``arvak-adapter-aqt`` (Rust REST client) reached via PyO3.
+
     Transpiles Qiskit circuits to the AQT native gate set (rz, rx, rxx) using
     Qiskit's transpiler, then serialises to AQT's JSON circuit format and
     submits to `https://arnica.aqt.eu/api/v1`.
@@ -2762,6 +2776,15 @@ class ArvakAQTBackend:
         workspace: str = 'default',
         resource: str = 'offline_simulator_no_noise',
     ):
+        import warnings
+        warnings.warn(
+            "ArvakAQTBackend is deprecated; "
+            "ArvakProvider.get_backend('aqt_*') now returns ArvakBackend "
+            "(native HAL-backed). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import requests as _requests
         self._requests = _requests
 
@@ -3129,6 +3152,15 @@ class ArvakAQTResult:
 class ArvakIonQBackend:
     """Arvak IonQ backend — submits directly to IonQ's REST API v0.4.
 
+    .. deprecated:: 2.5
+        Use :class:`ArvakBackend` instead.
+        ``ArvakProvider.get_backend('ionq_*')`` now returns the
+        native-HAL-backed class automatically (Phase 6). Direct
+        instantiation of this class still works but will be removed in
+        a future release. The native path replaces the in-Python
+        ``requests`` HTTP loop with ``arvak-adapter-ionq`` (Rust REST
+        client) reached via PyO3.
+
     Uses the IonQ **QIS gateset** — Arvak compiles to standard gates
     (h, cx, rx, ry, rz, etc.) and IonQ compiles to native gates server-side.
     All IonQ devices have all-to-all qubit connectivity.
@@ -3155,6 +3187,15 @@ class ArvakIonQBackend:
         provider,
         backend_name: str = 'simulator',
     ):
+        import warnings
+        warnings.warn(
+            "ArvakIonQBackend is deprecated; "
+            "ArvakProvider.get_backend('ionq_*') now returns ArvakBackend "
+            "(native HAL-backed). See "
+            "docs/RFC/0001-native-backend-unification.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import requests as _requests
         self._requests = _requests
 

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -724,6 +724,85 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // AQT (Alpine Quantum Technologies) — ion-trap simulators and
+        // IBEX Q1 hardware via the Arnica cloud API. AQT_TOKEN is
+        // required even for offline simulators (Arnica validates).
+        n if n.starts_with("aqt_") => {
+            #[cfg(feature = "adapter-aqt")]
+            {
+                // Registry name → (workspace, resource) on Arnica.
+                let (workspace, resource) = match n {
+                    "aqt_offline_sim" => ("default", "offline_simulator_no_noise"),
+                    "aqt_noise_sim" => ("default", "offline_simulator_noise"),
+                    "aqt_cloud_sim" => ("aqt_simulators", "simulator_noise"),
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown AQT backend: {other} \
+                             (known: aqt_offline_sim, aqt_noise_sim, aqt_cloud_sim)"
+                        )));
+                    }
+                };
+                // The adapter itself tolerates an empty AQT_TOKEN (offline
+                // sim path) but Arnica still validates tokens server-side.
+                // We surface a clearer error if the user hasn't set one.
+                if std::env::var("AQT_TOKEN")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .is_none()
+                {
+                    return Err(HalError::Configuration(
+                        "AQT_TOKEN not set — required by Arnica cloud API even for \
+                         offline simulators (confirmed 2026-02-21). Get a token from \
+                         arnica.aqt.eu."
+                            .into(),
+                    ));
+                }
+                let backend = arvak_adapter_aqt::AqtBackend::with_resource(workspace, resource)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-aqt"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "AQT adapter not compiled in for backend {n} (enable 'adapter-aqt' feature)"
+                )))
+            }
+        }
+        // IonQ — cloud simulator (29q free tier) + Aria-1/2 (25q) +
+        // Forte-1 (36q) trapped-ion QPUs via REST. Auth: IONQ_API_KEY.
+        n if n.starts_with("ionq_") => {
+            #[cfg(feature = "adapter-ionq")]
+            {
+                let device = match n {
+                    "ionq_simulator" => "simulator",
+                    "ionq_aria_1" => "qpu.aria-1",
+                    "ionq_aria_2" => "qpu.aria-2",
+                    "ionq_forte_1" => "qpu.forte-1",
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown IonQ backend: {other} \
+                             (known: ionq_simulator, ionq_aria_1, ionq_aria_2, ionq_forte_1)"
+                        )));
+                    }
+                };
+                std::env::var("IONQ_API_KEY").map_err(|_| {
+                    HalError::Configuration(
+                        "IONQ_API_KEY not set — required for IonQ Cloud API. \
+                         Get a key from cloud.ionq.com."
+                            .into(),
+                    )
+                })?;
+                let backend = arvak_adapter_ionq::IonQBackend::with_backend(device)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-ionq"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "IonQ adapter not compiled in for backend {n} (enable 'adapter-ionq' feature)"
+                )))
+            }
+        }
         // Quantinuum H1/H2 ion-trap systems (real hardware + emulators).
         // Auth via QUANTINUUM_EMAIL + QUANTINUUM_PASSWORD env vars.
         //
@@ -949,6 +1028,19 @@ fn known_backends() -> Vec<String> {
         v.push("quantinuum_h2".into());
         v.push("quantinuum_h2_emulator".into());
         v.push("quantinuum_h1_emulator".into());
+    }
+    #[cfg(feature = "adapter-aqt")]
+    {
+        v.push("aqt_offline_sim".into());
+        v.push("aqt_noise_sim".into());
+        v.push("aqt_cloud_sim".into());
+    }
+    #[cfg(feature = "adapter-ionq")]
+    {
+        v.push("ionq_simulator".into());
+        v.push("ionq_aria_1".into());
+        v.push("ionq_aria_2".into());
+        v.push("ionq_forte_1".into());
     }
     #[cfg(feature = "adapter-ibm")]
     {


### PR DESCRIPTION
## Summary

`ArvakProvider.get_backend('aqt_*')` and `ArvakProvider.get_backend('ionq_*')`
now both route through the native Rust adapters (`arvak-adapter-aqt` /
`arvak-adapter-ionq`) via PyO3. Replaces the in-Python `requests`
loops in `ArvakAQTBackend` and `ArvakIonQBackend`.

Both vendors have no multi-framework footprint — qrisp's
`_HARDWARE_BACKENDS` is `{iqm, scaleway}`. RFC §Phase 6 impact map:
`n/a` across cirq/pennylane/qrisp.

## What changed

| Component | Change |
|---|---|
| **Cargo features** | New `adapter-aqt`, `adapter-ionq`, both in `default` |
| **`make_backend()`** | New prefix branches for `aqt_*` and `ionq_*`, mapping registry names to vendor identifiers |
| **IonQ adapter** | Per-target qubit fix: added `qubits_for_backend()` helper so `qpu.forte-1` reports 36 qubits (was 25). Matches legacy `_BACKEND_QUBITS` dict |
| **AQT adapter** | Unchanged — already correct at 20 qubits |
| **`known_backends()`** | Lists three AQT + four IonQ targets |
| **qiskit `ArvakProvider`** | `aqt_*` and `ionq_*` lookups return `ArvakBackend` (native) |
| **`ArvakAQTBackend`, `ArvakIonQBackend`** | Importable, emit `DeprecationWarning` at construction |

## Hidden-behaviour audit (RFC §Risks #2)

- **AQT**: legacy class hardcoded `MAX_QUBITS = 20`; native adapter
  already had `AQT_MAX_QUBITS = 20`. Match — no fix needed.
- **IonQ**: legacy class had per-target dict (`simulator: 29,
  aria: 25, forte: 36`). Native adapter previously used a single
  `QPU_MAX_QUBITS = 25` for everything, which would have made
  `forte-1` under-report by 11 qubits. **Fixed** in this PR via
  `qubits_for_backend()` helper.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-python --lib backend::`: 6 passed
- [x] `cargo test -p arvak-adapter-aqt --lib`: 28 passed
- [x] `cargo test -p arvak-adapter-ionq --lib`: 31 passed (incl. the
      qubit refactor)
- [x] 52/52 pre-existing qiskit + circuit tests pass
- [x] All earlier-phase smoke tests still pass
- [x] 15 new Phase-6 smoke tests:
  - AQT: listing, unknown rejected, missing token error, construction,
    routing, deprecation
  - IonQ: listing, unknown rejected, missing key error, **per-target
    qubits 29/25/25/36 (incl. forte fix)**, routing, deprecation
  - qrisp: no aqt/ionq bypass
  - Compat: sim + earlier phases unaffected
- [ ] CI: this PR's run

## After this PR

| Phase | Status |
|---|---|
| 0 RFC | ✅ |
| 1 native sim | ✅ |
| 1.5 A1/A2 | ✅ |
| 2a IQM Cloud | ✅ |
| 2b LUMI/LRZ OIDC | ✅ |
| 3 Scaleway | ✅ |
| 4 IBM | ✅ |
| 5 Quantinuum (ionshuttler skipped) | ✅ |
| **6 AQT + IonQ** | **this PR** |
| 7 Cleanup (delete legacy classes, major version bump) | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)