### PR TITLE
feat(python): RFC-0001 Phase 6.5 — wire native Quandela adapter (gap fill)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "arvak-adapter-ibm",
  "arvak-adapter-ionq",
  "arvak-adapter-iqm",
+ "arvak-adapter-quandela",
  "arvak-adapter-quantinuum",
  "arvak-adapter-scaleway",
  "arvak-adapter-sim",

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,7 +11,7 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum", "adapter-aqt", "adapter-ionq"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum", "adapter-aqt", "adapter-ionq", "adapter-quandela"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
 adapter-scaleway = ["arvak-adapter-scaleway"]
@@ -19,6 +19,7 @@ adapter-ibm = ["arvak-adapter-ibm"]
 adapter-quantinuum = ["arvak-adapter-quantinuum"]
 adapter-aqt = ["arvak-adapter-aqt"]
 adapter-ionq = ["arvak-adapter-ionq"]
+adapter-quandela = ["arvak-adapter-quandela"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -33,6 +34,7 @@ arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true
 arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
 arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
 arvak-adapter-ionq = { path = "../../adapters/arvak-adapter-ionq", optional = true }
+arvak-adapter-quandela = { workspace = true, optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -724,6 +724,47 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 ))
             }
         }
+        // Quandela — photonic QPUs and simulators via Perceval Cloud.
+        // Auth: PCVL_CLOUD_TOKEN env var (Perceval's convention; the
+        // adapter passes this to a Perceval Python subprocess bridge).
+        // Platform layout from arvak_adapter_quandela::backend:
+        //   sim:ascella (6q free sim)  qpu:ascella (6q QPU)
+        //   sim:belenos (12q sim)      qpu:belenos (12q QPU, 2025)
+        //   quandela_altair (legacy Altair 4K cryocooled, 5q —
+        //     also the Alsvid PUF target)
+        n if n.starts_with("quandela_") => {
+            #[cfg(feature = "adapter-quandela")]
+            {
+                let platform = match n {
+                    "quandela_ascella_sim" => "sim:ascella",
+                    "quandela_ascella" => "qpu:ascella",
+                    "quandela_belenos_sim" => "sim:belenos",
+                    "quandela_belenos" => "qpu:belenos",
+                    "quandela_altair" => "quandela_altair",
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown Quandela backend: {other} \
+                             (known: quandela_ascella_sim, quandela_ascella, \
+                             quandela_belenos_sim, quandela_belenos, quandela_altair)"
+                        )));
+                    }
+                };
+                // PCVL_CLOUD_TOKEN is required for Quandela Cloud platforms.
+                // The `sim:*` simulators may run without it via local mock,
+                // but the Perceval bridge consults the env var either way.
+                // We don't gate on it here — let the bridge surface the
+                // auth error with its own Perceval-specific message.
+                let backend = arvak_adapter_quandela::QuandelaBackend::for_platform(platform)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-quandela"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "Quandela adapter not compiled in for backend {n} (enable 'adapter-quandela' feature)"
+                )))
+            }
+        }
         // AQT (Alpine Quantum Technologies) — ion-trap simulators and
         // IBEX Q1 hardware via the Arnica cloud API. AQT_TOKEN is
         // required even for offline simulators (Arnica validates).
@@ -1041,6 +1082,14 @@ fn known_backends() -> Vec<String> {
         v.push("ionq_aria_1".into());
         v.push("ionq_aria_2".into());
         v.push("ionq_forte_1".into());
+    }
+    #[cfg(feature = "adapter-quandela")]
+    {
+        v.push("quandela_ascella_sim".into());
+        v.push("quandela_ascella".into());
+        v.push("quandela_belenos_sim".into());
+        v.push("quandela_belenos".into());
+        v.push("quandela_altair".into());
     }
     #[cfg(feature = "adapter-ibm")]
     {


### PR DESCRIPTION
## Summary

Quandela was missing from the Python backend registry — gap discovered
after Phase 6 when the user flagged \"darauf haben wir auch schon
gerechnet\". The native `arvak-adapter-quandela` and gRPC registration
have existed since the Alsvid PUF work, but
`arvak.integrations.qiskit.ArvakProvider` never knew about it. No
legacy `ArvakQuandelaBackend` class existed — this is a pure additive
change.

Five platforms now reachable via `arvak.backend_for(name)`:

| Registry name | Perceval platform | Qubits | Type |
|---|---|---|---|
| `quandela_ascella_sim` | `sim:ascella` | 6 | simulator |
| `quandela_ascella` | `qpu:ascella` | 6 | physical QPU |
| `quandela_belenos_sim` | `sim:belenos` | 12 | simulator |
| `quandela_belenos` | `qpu:belenos` | 12 | physical QPU (2025) |
| `quandela_altair` | `quandela_altair` | 5 | legacy 4K cryocooled |

Auth via `PCVL_CLOUD_TOKEN` (Perceval's standard env var), passed
through to the Python subprocess bridge.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace --exclude arvak-python` green
- [x] `cargo test -p arvak-adapter-quandela --lib`: unchanged
- [x] 52/52 pre-existing qiskit + circuit tests pass
- [x] All earlier-phase smoke tests pass
- [x] 8 Phase-6.5 smoke tests: listing, unknown rejected, per-platform
      qubit counts, sim flag, confirmation no legacy class exists,
      confirmation no `_QUANDELA_BACKENDS` routing, sim + earlier
      phases unaffected
- [ ] CI: this PR's run

## Out of scope

Three more adapters are in the same "native built but not in
registry" state and will land in Phase 6.6: braket, cudaq, ddsim.

qdmi is a different shape (driver-discovery interface, not a single
backend) and gets its own phase.

D-Wave and qbraid intentionally not included: different abstraction
(QUBO/Ising vs gate-based) and meta-cloud-over-meta-cloud,
respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)