### PR TITLE
RFC-0001 Phase 6.6 — wire native Braket + CUDA-Q + DDSIM adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,9 @@ name = "arvak-python"
 version = "1.9.5"
 dependencies = [
  "arvak-adapter-aqt",
+ "arvak-adapter-braket",
+ "arvak-adapter-cudaq",
+ "arvak-adapter-ddsim",
  "arvak-adapter-ibm",
  "arvak-adapter-ionq",
  "arvak-adapter-iqm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ arvak-proj = { path = "crates/arvak-proj" }
 arvak-adapter-sim = { path = "adapters/arvak-adapter-sim" }
 arvak-adapter-ddsim = { path = "adapters/arvak-adapter-ddsim" }
 arvak-adapter-braket = { path = "adapters/arvak-adapter-braket" }
+arvak-adapter-cudaq = { path = "adapters/arvak-adapter-cudaq" }
 arvak-adapter-ionq = { path = "adapters/arvak-adapter-ionq" }
 arvak-adapter-quandela = { path = "adapters/arvak-adapter-quandela" }
 

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -11,7 +11,7 @@ name = "arvak"
 crate-type = ["cdylib"]
 
 [features]
-default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum", "adapter-aqt", "adapter-ionq", "adapter-quandela"]
+default = ["simulator", "adapter-iqm", "adapter-scaleway", "adapter-ibm", "adapter-quantinuum", "adapter-aqt", "adapter-ionq", "adapter-quandela", "adapter-braket", "adapter-cudaq", "adapter-ddsim"]
 simulator = ["arvak-adapter-sim"]
 adapter-iqm = ["arvak-adapter-iqm"]
 adapter-scaleway = ["arvak-adapter-scaleway"]
@@ -20,6 +20,9 @@ adapter-quantinuum = ["arvak-adapter-quantinuum"]
 adapter-aqt = ["arvak-adapter-aqt"]
 adapter-ionq = ["arvak-adapter-ionq"]
 adapter-quandela = ["arvak-adapter-quandela"]
+adapter-braket = ["arvak-adapter-braket"]
+adapter-cudaq = ["arvak-adapter-cudaq"]
+adapter-ddsim = ["arvak-adapter-ddsim"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
@@ -35,6 +38,9 @@ arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", o
 arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
 arvak-adapter-ionq = { path = "../../adapters/arvak-adapter-ionq", optional = true }
 arvak-adapter-quandela = { workspace = true, optional = true }
+arvak-adapter-braket = { workspace = true, optional = true }
+arvak-adapter-cudaq = { workspace = true, optional = true }
+arvak-adapter-ddsim = { workspace = true, optional = true }
 arvak-sim = { workspace = true }
 arvak-proj = { workspace = true }
 num-complex = { workspace = true }

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -844,6 +844,122 @@ fn make_backend(name: &str) -> Result<Arc<dyn Backend + Send + Sync>, HalError> 
                 )))
             }
         }
+        // AWS Braket — managed quantum service. Cloud simulators (SV1/
+        // TN1/DM1) plus QPU access to Rigetti Ankaa-3, IonQ Aria-1/2/
+        // Forte-1, and IQM Garnet. Auth via standard AWS chain (env,
+        // SSO, config, IAM role). Requires ARVAK_BRAKET_S3_BUCKET for
+        // task result storage. Device ARN constants live in
+        // arvak_adapter_braket::device.
+        n if n.starts_with("braket_") => {
+            #[cfg(feature = "adapter-braket")]
+            {
+                use arvak_adapter_braket::device;
+                let arn = match n {
+                    "braket_sv1" => device::SV1,
+                    "braket_tn1" => device::TN1,
+                    "braket_dm1" => device::DM1,
+                    "braket_rigetti_ankaa" => device::RIGETTI_ANKAA_3,
+                    "braket_ionq_aria_1" => device::IONQ_ARIA,
+                    "braket_ionq_aria_2" => device::IONQ_ARIA_2,
+                    "braket_ionq_forte_1" => device::IONQ_FORTE,
+                    "braket_iqm_garnet" => device::IQM_GARNET,
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown Braket backend: {other} \
+                             (known: braket_sv1, braket_tn1, braket_dm1, \
+                             braket_rigetti_ankaa, braket_ionq_aria_1, \
+                             braket_ionq_aria_2, braket_ionq_forte_1, \
+                             braket_iqm_garnet)"
+                        )));
+                    }
+                };
+                // ARVAK_BRAKET_S3_BUCKET is required by the adapter for
+                // result storage. Surface it before going async so the
+                // user gets a clear message rather than an opaque
+                // BraketError::MissingS3Bucket from inside connect().
+                std::env::var("ARVAK_BRAKET_S3_BUCKET").map_err(|_| {
+                    HalError::Configuration(
+                        "ARVAK_BRAKET_S3_BUCKET not set — required for Braket task results. \
+                         Create an S3 bucket and grant Braket write access (see AWS docs)."
+                            .into(),
+                    )
+                })?;
+                // BraketBackend::connect() is async (initializes AWS
+                // SDK client + fetches device info for unknown ARNs).
+                let backend = runtime()
+                    .block_on(arvak_adapter_braket::BraketBackend::connect(arn))
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-braket"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "Braket adapter not compiled in for backend {n} (enable 'adapter-braket' feature)"
+                )))
+            }
+        }
+        // NVIDIA CUDA-Q — GPU-accelerated simulators (and eventually
+        // hardware backends) via REST. Targets:
+        //   cudaq_mqpu          → nvidia-mqpu (40q multi-GPU statevector)
+        //   cudaq_custatevec    → custatevec  (32q single-GPU statevector)
+        //   cudaq_tensornet     → tensornet   (100q tensor-network)
+        //   cudaq_density_matrix→ density-matrix (20q noise sim)
+        // Auth via CUDAQ_API_TOKEN.
+        n if n.starts_with("cudaq_") => {
+            #[cfg(feature = "adapter-cudaq")]
+            {
+                let target = match n {
+                    "cudaq_mqpu" => arvak_adapter_cudaq::targets::MQPU,
+                    "cudaq_custatevec" => arvak_adapter_cudaq::targets::CUSTATEVEC,
+                    "cudaq_tensornet" => arvak_adapter_cudaq::targets::TENSORNET,
+                    "cudaq_density_matrix" => arvak_adapter_cudaq::targets::DM,
+                    other => {
+                        return Err(HalError::Configuration(format!(
+                            "unknown CUDA-Q backend: {other} \
+                             (known: cudaq_mqpu, cudaq_custatevec, cudaq_tensornet, \
+                             cudaq_density_matrix)"
+                        )));
+                    }
+                };
+                // CUDAQ_API_TOKEN is read by CudaqBackend::with_target() —
+                // pre-check it here to provide a clearer error than
+                // CudaqError::MissingToken.
+                std::env::var("CUDAQ_API_TOKEN").map_err(|_| {
+                    HalError::Configuration(
+                        "CUDAQ_API_TOKEN not set — required for NVIDIA CUDA-Q Cloud API. \
+                         Get a token from build.nvidia.com → API keys."
+                            .into(),
+                    )
+                })?;
+                let backend = arvak_adapter_cudaq::CudaqBackend::with_target(target)
+                    .map_err(|e| HalError::Backend(e.to_string()))?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "adapter-cudaq"))]
+            {
+                Err(HalError::Configuration(format!(
+                    "CUDA-Q adapter not compiled in for backend {n} (enable 'adapter-cudaq' feature)"
+                )))
+            }
+        }
+        // MQT DDSIM — local decision-diagram simulator. Runs out-of-
+        // process via a python3 subprocess (`pip install mqt.ddsim`).
+        // No cloud auth. The bare name "ddsim" maps to default
+        // settings (128q ceiling); future targets like ddsim_path,
+        // ddsim_hybrid can be added if/when we wire alternative DDSIM
+        // engines.
+        "ddsim" => {
+            #[cfg(feature = "adapter-ddsim")]
+            {
+                Ok(Arc::new(arvak_adapter_ddsim::DdsimBackend::new()))
+            }
+            #[cfg(not(feature = "adapter-ddsim"))]
+            {
+                Err(HalError::Configuration(
+                    "DDSIM adapter not compiled in (enable 'adapter-ddsim' feature)".into(),
+                ))
+            }
+        }
         // Quantinuum H1/H2 ion-trap systems (real hardware + emulators).
         // Auth via QUANTINUUM_EMAIL + QUANTINUUM_PASSWORD env vars.
         //
@@ -1090,6 +1206,30 @@ fn known_backends() -> Vec<String> {
         v.push("quandela_belenos_sim".into());
         v.push("quandela_belenos".into());
         v.push("quandela_altair".into());
+    }
+    #[cfg(feature = "adapter-braket")]
+    {
+        // Amazon managed simulators
+        v.push("braket_sv1".into());
+        v.push("braket_tn1".into());
+        v.push("braket_dm1".into());
+        // QPUs (auth + S3 bucket required at construction)
+        v.push("braket_rigetti_ankaa".into());
+        v.push("braket_ionq_aria_1".into());
+        v.push("braket_ionq_aria_2".into());
+        v.push("braket_ionq_forte_1".into());
+        v.push("braket_iqm_garnet".into());
+    }
+    #[cfg(feature = "adapter-cudaq")]
+    {
+        v.push("cudaq_mqpu".into());
+        v.push("cudaq_custatevec".into());
+        v.push("cudaq_tensornet".into());
+        v.push("cudaq_density_matrix".into());
+    }
+    #[cfg(feature = "adapter-ddsim")]
+    {
+        v.push("ddsim".into());
     }
     #[cfg(feature = "adapter-ibm")]
     {


### PR DESCRIPTION
## Summary

Native registry coverage extended to three more in-tree adapters that were never reachable from Python via `arvak.backend_for()`. Same pure-additive shape as Phase 6.5 — no legacy class to deprecate, no qiskit/qrisp routing change.

After this PR, **every adapter under `adapters/` except QDMI is in the native registry**. QDMI is intentionally deferred (driver discovery is a different architecture).

| Vendor | Registry names | Adapter call | Auth |
|---|---|---|---|
| Braket | `braket_sv1`, `braket_tn1`, `braket_dm1`, `braket_rigetti_ankaa`, `braket_ionq_aria_{1,2}`, `braket_ionq_forte_1`, `braket_iqm_garnet` | `BraketBackend::connect(ARN).await` via `runtime().block_on()` | AWS default chain + `ARVAK_BRAKET_S3_BUCKET` |
| CUDA-Q | `cudaq_mqpu`, `cudaq_custatevec`, `cudaq_tensornet`, `cudaq_density_matrix` | `CudaqBackend::with_target(target)` | `CUDAQ_API_TOKEN` |
| DDSIM | `ddsim` | `DdsimBackend::new()` | none (local subprocess) |

13 new backend names. ARNs/target IDs are taken from the adapter crates (`arvak_adapter_braket::device::*` and `arvak_adapter_cudaq::targets::*`) — never duplicated in the registry.

## Test plan

- [x] `cargo check -p arvak-python` — clean
- [x] `cargo check --workspace --exclude arvak-python` — clean
- [x] `cargo test -p arvak-python` — 8/8 pass
- [x] `cargo fmt --all` — clean
- [x] `maturin develop --release` — editable wheel builds
- [x] Phase 6.6 smoke: 11/11 pass (registry / unknown rejection / env-var gating / per-target qubit counts / DDSIM no-auth path)
- [x] Phase 6.5 smoke: 8/8 pass (no regression in Quandela path)
- [x] Phase 6 smoke: 15/15 pass (no regression in AQT/IonQ paths)
- [ ] CI: this PR's run

## Risk audit (RFC §Risks)

- **Per-target qubit count:** validated against the adapters' own match tables (`backend.rs` for CUDA-Q; `device::capabilities_for_device` for Braket). DDSIM uses the adapter's `DEFAULT_MAX_QUBITS = 128`.
- **Env-var pre-validation:** same pattern as Phase 4/5/6 — clearer message than the adapter's raw `MissingFoo` variant.
- **Feature gating:** each new branch has a `#[cfg(not(feature = ...))]` arm so disabling a feature gives a "not compiled in" error rather than "unknown backend".
- **No live hardware calls in smoke:** Braket smoke verifies the S3-bucket pre-check but does **not** call `connect()` with a bucket set, since that triggers real AWS SDK initialisation.

## Roadmap update

Closes the additive part of RFC-0001 except for QDMI. Phase 6.7 = QDMI driver-discovery sprint. Phase 7 = cleanup (delete 7 deprecated legacy classes + 7 legacy Job classes + major version bump). D-Wave and qbraid remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)