### PR TITLE
feat(iqm): migrate IQM adapter to Resonance v1 API (HAL-thin)

### DIFF
--- a/adapters/arvak-adapter-iqm/src/api.rs
+++ b/adapters/arvak-adapter-iqm/src/api.rs
@@ -1,10 +1,34 @@
-//! IQM Resonance API client.
+//! IQM Resonance v1 API client.
 //!
-//! This module implements the IQM Resonance REST API for submitting
-//! quantum circuits and retrieving results.
+//! Talks to the public IQM Resonance REST API rooted at
+//! `https://resonance.iqm.tech/api/v1`. Authentication is a Bearer
+//! token from the user's API tokens page (the `IQM_TOKEN` env var
+//! the rest of the adapter already reads).
+//!
+//! # API surface
+//!
+//! The Resonance v1 surface differs significantly from the retired
+//! `cocos.resonance.meetiqm.com/api/v1` interface this adapter used to
+//! target. Notable differences:
+//!
+//! - Job submission is `POST /jobs/{qc}/{job_type}` — the quantum
+//!   computer alias (or UUID) and the job type are part of the URL,
+//!   not the body. Only `circuit` is currently a valid job type for
+//!   live QPUs.
+//! - Job status comes back in the `GET /jobs/{job_id}` response body
+//!   (there is no separate `/status` endpoint).
+//! - Measurement results live under
+//!   `GET /jobs/{job_id}/artifacts/measurement_counts` (the artifact
+//!   names are advertised in the `Job.artifacts` array).
+//! - Status enum is `{waiting, processing, completed, failed, cancelled}`.
+//! - The submission body for `circuit` jobs uses the IQM IR JSON
+//!   shape — each instruction is `{name, locus, args, implementation}`
+//!   where `locus` is a list of qubit labels (`"QB1"`, `"QB2"`, ...).
+//!
+//! The HAL `Backend` trait only requires this adapter to translate
+//! the user's already-IQM-native circuit into this wire shape. Lowering
+//! arbitrary gates to PRX/CZ is `arvak-compile`'s job, not ours.
 
-// Allow dead code for API response fields that are deserialized but not yet used.
-// These fields are part of the IQM API contract and may be useful in the future.
 #![allow(dead_code)]
 
 use reqwest::{Client, StatusCode};
@@ -14,12 +38,12 @@ use tracing::{debug, instrument};
 
 use crate::error::{IqmError, IqmResult};
 
-/// IQM Resonance API client.
+/// IQM Resonance v1 API client.
 #[derive(Clone)]
 pub struct IqmClient {
     /// HTTP client.
     client: Client,
-    /// API base URL.
+    /// API base URL (e.g. `https://resonance.iqm.tech/api/v1`).
     base_url: String,
     /// Authentication token.
     token: String,
@@ -35,7 +59,7 @@ impl std::fmt::Debug for IqmClient {
 }
 
 impl IqmClient {
-    /// Create a new IQM client.
+    /// Create a new IQM Resonance client.
     pub fn new(base_url: impl Into<String>, token: impl Into<String>) -> IqmResult<Self> {
         let base_url = base_url.into();
         let token = token.into();
@@ -57,65 +81,99 @@ impl IqmClient {
         })
     }
 
-    /// Submit a circuit for execution.
+    /// Build the standard request headers (auth + a non-empty UA).
+    ///
+    /// Resonance is fronted by Cloudflare and 1010-blocks bare HTTP
+    /// clients without a User-Agent. The string itself is not
+    /// version-gated; anything non-empty passes.
+    fn auth_headers(&self) -> reqwest::header::HeaderMap {
+        use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+        let mut h = HeaderMap::new();
+        h.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", self.token))
+                .expect("IQM token contains non-ASCII; rejected at insertion"),
+        );
+        h.insert(
+            USER_AGENT,
+            HeaderValue::from_static("arvak-adapter-iqm/1.0"),
+        );
+        h.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        h
+    }
+
+    /// Submit a `circuit` job to a quantum computer.
     #[instrument(skip(self, request))]
-    pub async fn submit_job(&self, request: &SubmitRequest) -> IqmResult<SubmitResponse> {
-        let url = format!("{}/jobs", self.base_url);
-        debug!("Submitting job to {}", url);
+    pub async fn submit_circuit(&self, qc: &str, request: &SubmitRequest) -> IqmResult<Job> {
+        let url = format!("{}/jobs/{}/circuit?use_timeslot=false", self.base_url, qc);
+        debug!("POST {}", url);
 
         let response = self
             .client
             .post(&url)
-            .bearer_auth(&self.token)
+            .headers(self.auth_headers())
             .json(request)
             .send()
             .await?;
 
-        self.handle_response(response).await
+        Self::handle_response(response).await
     }
 
-    /// Get the status of a job.
+    /// Fetch a job by id (status + metadata).
+    ///
+    /// The returned [`Job`] carries the current `status` field. There
+    /// is no separate `/status` endpoint on the v1 API — this single
+    /// GET replaces the legacy two-call pattern.
     #[instrument(skip(self))]
-    pub async fn get_job_status(&self, job_id: &str) -> IqmResult<JobStatusResponse> {
-        let url = format!("{}/jobs/{}/status", self.base_url, job_id);
-        debug!("Getting job status from {}", url);
-
-        let response = self
-            .client
-            .get(&url)
-            .bearer_auth(&self.token)
-            .send()
-            .await?;
-
-        self.handle_response(response).await
-    }
-
-    /// Get the result of a completed job.
-    #[instrument(skip(self))]
-    pub async fn get_job_result(&self, job_id: &str) -> IqmResult<JobResultResponse> {
+    pub async fn get_job(&self, job_id: &str) -> IqmResult<Job> {
         let url = format!("{}/jobs/{}", self.base_url, job_id);
-        debug!("Getting job result from {}", url);
+        debug!("GET {}", url);
 
         let response = self
             .client
             .get(&url)
-            .bearer_auth(&self.token)
+            .headers(self.auth_headers())
             .send()
             .await?;
 
-        self.handle_response(response).await
+        Self::handle_response(response).await
     }
 
-    /// Cancel a job.
+    /// Fetch the `measurement_counts` artifact for a completed job.
+    ///
+    /// Returns a list of per-circuit count blocks; for a single-
+    /// circuit job (the only shape this adapter currently submits)
+    /// the list has one entry whose `counts` map is keyed by the
+    /// concatenated bitstring as IQM serialises it (instruction
+    /// order, not qubit-id order — caller may need to re-index).
+    #[instrument(skip(self))]
+    pub async fn get_measurement_counts(&self, job_id: &str) -> IqmResult<Vec<MeasurementCounts>> {
+        let url = format!(
+            "{}/jobs/{}/artifacts/measurement_counts",
+            self.base_url, job_id
+        );
+        debug!("GET {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+
+        Self::handle_response(response).await
+    }
+
+    /// Cancel a queued or running job.
     #[instrument(skip(self))]
     pub async fn cancel_job(&self, job_id: &str) -> IqmResult<()> {
         let url = format!("{}/jobs/{}/cancel", self.base_url, job_id);
-        debug!("Cancelling job at {}", url);
+        debug!("POST {}", url);
 
         let response = self
             .client
             .post(&url)
-            .bearer_auth(&self.token)
+            .headers(self.auth_headers())
             .send()
             .await?;
 
@@ -128,281 +186,289 @@ impl IqmClient {
         }
     }
 
-    /// Get backend information.
+    /// Get a quantum computer's job-size limits.
     #[instrument(skip(self))]
-    pub async fn get_backend_info(&self, backend_name: &str) -> IqmResult<BackendInfo> {
-        let url = format!("{}/quantum-computers/{}", self.base_url, backend_name);
-        debug!("Getting backend info from {}", url);
+    pub async fn get_qc_limits(&self, qc: &str) -> IqmResult<QcLimits> {
+        let url = format!("{}/quantum-computers/{}/limits", self.base_url, qc);
+        debug!("GET {}", url);
 
         let response = self
             .client
             .get(&url)
-            .bearer_auth(&self.token)
+            .headers(self.auth_headers())
             .send()
             .await?;
 
-        self.handle_response(response).await
+        Self::handle_response(response).await
     }
 
-    /// List available backends.
+    /// Get a quantum computer's health status.
     #[instrument(skip(self))]
-    pub async fn list_backends(&self) -> IqmResult<Vec<BackendInfo>> {
+    pub async fn get_qc_health(&self, qc: &str) -> IqmResult<QcHealthStatus> {
+        let url = format!("{}/quantum-computers/{}/health", self.base_url, qc);
+        debug!("GET {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+
+        Self::handle_response(response).await
+    }
+
+    /// List all quantum computers visible to this token.
+    #[instrument(skip(self))]
+    pub async fn list_quantum_computers(&self) -> IqmResult<Vec<QuantumComputer>> {
         let url = format!("{}/quantum-computers", self.base_url);
-        debug!("Listing backends from {}", url);
+        debug!("GET {}", url);
 
         let response = self
             .client
             .get(&url)
-            .bearer_auth(&self.token)
+            .headers(self.auth_headers())
             .send()
             .await?;
 
-        self.handle_response(response).await
+        let envelope: QuantumComputerList = Self::handle_response(response).await?;
+        Ok(envelope.quantum_computers)
     }
 
-    /// Handle HTTP response, extracting JSON or returning error.
+    /// Map a 4xx/5xx response to a typed error.
     async fn handle_response<T: for<'de> Deserialize<'de>>(
-        &self,
         response: reqwest::Response,
     ) -> IqmResult<T> {
         let status = response.status();
 
         if status.is_success() {
             let body = response.json().await?;
-            Ok(body)
-        } else {
-            let message = response.text().await.unwrap_or_default();
+            return Ok(body);
+        }
 
-            match status {
-                StatusCode::UNAUTHORIZED => Err(IqmError::AuthFailed(message)),
-                StatusCode::NOT_FOUND => Err(IqmError::JobNotFound(message)),
-                _ => Err(IqmError::ApiError {
-                    status: status.as_u16(),
-                    message,
-                }),
-            }
+        let message = response.text().await.unwrap_or_default();
+        match status {
+            StatusCode::UNAUTHORIZED => Err(IqmError::AuthFailed(message)),
+            StatusCode::NOT_FOUND => Err(IqmError::JobNotFound(message)),
+            _ => Err(IqmError::ApiError {
+                status: status.as_u16(),
+                message,
+            }),
         }
     }
 }
 
-/// Request to submit a job.
+// ---------------------------------------------------------------------------
+// Request / response types — IQM Resonance v1 JSON wire format
+// ---------------------------------------------------------------------------
+
+/// Submission body for `POST /jobs/{qc}/circuit`.
+///
+/// The IQM IR JSON shape: one or more circuits, each a list of
+/// instructions in IQM-native form, plus the shot count.
 #[derive(Debug, Clone, Serialize)]
 pub struct SubmitRequest {
-    /// Target quantum computer.
-    pub backend: String,
-    /// Circuit in `OpenQASM` 3 format.
-    pub program: String,
-    /// Number of shots.
+    /// Circuits to execute (we currently only submit one per job).
+    pub circuits: Vec<IqmCircuit>,
+    /// Number of shots (per circuit).
     pub shots: u32,
-    /// Optional job name.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// Optional job tags.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<String>>,
-    /// Execution options.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<ExecutionOptions>,
 }
 
 impl SubmitRequest {
-    /// Create a new submit request.
-    pub fn new(backend: impl Into<String>, program: impl Into<String>, shots: u32) -> Self {
+    /// Construct a single-circuit submission.
+    pub fn single(circuit: IqmCircuit, shots: u32) -> Self {
         Self {
-            backend: backend.into(),
-            program: program.into(),
+            circuits: vec![circuit],
             shots,
-            name: None,
-            tags: None,
-            options: None,
         }
     }
-
-    /// Set job name.
-    pub fn with_name(mut self, name: impl Into<String>) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    /// Set job tags.
-    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
-        self.tags = Some(tags);
-        self
-    }
-
-    /// Set execution options.
-    pub fn with_options(mut self, options: ExecutionOptions) -> Self {
-        self.options = Some(options);
-        self
-    }
 }
 
-/// Execution options for job submission.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExecutionOptions {
-    /// Circuit optimization level (0-3).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub optimization_level: Option<u8>,
-    /// Maximum execution time in seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_execution_time: Option<u64>,
-    /// Use error mitigation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_mitigation: Option<bool>,
+/// One circuit in IQM IR JSON form.
+#[derive(Debug, Clone, Serialize)]
+pub struct IqmCircuit {
+    /// Free-form name used for debugging/Resonance UI display.
+    pub name: String,
+    /// Instructions in execution order.
+    pub instructions: Vec<IqmInstruction>,
 }
 
-impl Default for ExecutionOptions {
-    fn default() -> Self {
+/// One IQM-native instruction.
+///
+/// Examples (from a real Resonance payload):
+///
+/// ```text
+/// { "name": "prx",     "locus": ["QB1"],            "args": {"angle": 1.5708, "phase": 0.0}, "implementation": null }
+/// { "name": "cz",      "locus": ["QB1", "QB2"],     "args": {},                              "implementation": null }
+/// { "name": "measure", "locus": ["QB1"],            "args": {"key": "c_0_0_0"},              "implementation": null }
+/// ```
+#[derive(Debug, Clone, Serialize)]
+pub struct IqmInstruction {
+    /// Operation name: `prx`, `cz`, `move`, `measure`, ...
+    pub name: String,
+    /// Qubit / classical register labels this instruction acts on.
+    pub locus: Vec<String>,
+    /// Operation arguments (e.g. `{angle, phase}` for `prx`, `{key}` for `measure`).
+    #[serde(default)]
+    pub args: serde_json::Value,
+    /// Implementation override (always `null` for client-submitted circuits).
+    pub implementation: Option<String>,
+}
+
+impl IqmInstruction {
+    /// Build a `prx(angle, phase)` instruction.
+    pub fn prx(qubit: &str, angle: f64, phase: f64) -> Self {
         Self {
-            optimization_level: Some(1),
-            max_execution_time: None,
-            error_mitigation: None,
+            name: "prx".into(),
+            locus: vec![qubit.to_string()],
+            args: serde_json::json!({"angle": angle, "phase": phase}),
+            implementation: None,
+        }
+    }
+
+    /// Build a `cz` instruction on two qubits.
+    pub fn cz(q1: &str, q2: &str) -> Self {
+        Self {
+            name: "cz".into(),
+            locus: vec![q1.to_string(), q2.to_string()],
+            args: serde_json::json!({}),
+            implementation: None,
+        }
+    }
+
+    /// Build a `measure` instruction with the given result key.
+    pub fn measure(qubit: &str, key: &str) -> Self {
+        Self {
+            name: "measure".into(),
+            locus: vec![qubit.to_string()],
+            args: serde_json::json!({"key": key}),
+            implementation: None,
         }
     }
 }
 
-/// Response from job submission.
+/// A submitted job (response from submit / get-job / cancel).
 #[derive(Debug, Clone, Deserialize)]
-pub struct SubmitResponse {
-    /// Job identifier.
+pub struct Job {
+    /// Job UUID.
     pub id: String,
-    /// Job status.
-    pub status: String,
-    /// Estimated queue position.
+    /// Job type (currently always `"circuit"`).
+    #[serde(default)]
+    pub r#type: Option<String>,
+    /// Target quantum computer.
+    #[serde(default)]
+    pub qc: Option<JobQc>,
+    /// Current status.
+    pub status: JobStatusValue,
+    /// Wall-clock runtime in milliseconds (populated when terminal).
+    #[serde(default)]
+    pub runtime_ms: Option<u64>,
+    /// Position in queue, if applicable.
     #[serde(default)]
     pub queue_position: Option<u32>,
-    /// Estimated wait time in seconds.
+    /// Per-source/state timeline.
     #[serde(default)]
-    pub estimated_wait_time: Option<u64>,
+    pub timeline: Vec<JobTimelineEvent>,
+    /// Errors leading to a `failed` status.
+    #[serde(default)]
+    pub errors: Option<Vec<JobError>>,
+    /// Artifact descriptors (use the `type` field to GET each artifact).
+    #[serde(default)]
+    pub artifacts: Vec<JobArtifact>,
 }
 
-/// Job status response.
+/// Reference to the QC a job targets.
 #[derive(Debug, Clone, Deserialize)]
-pub struct JobStatusResponse {
-    /// Job identifier.
+pub struct JobQc {
     pub id: String,
-    /// Current status.
+}
+
+/// One step in a job's processing timeline.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JobTimelineEvent {
+    pub source: String,
     pub status: String,
-    /// Status message.
+    pub timestamp: String,
+}
+
+/// Descriptor of an artifact available for a job.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JobArtifact {
+    pub r#type: String,
+}
+
+/// Error report on a failed job.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JobError {
     #[serde(default)]
     pub message: Option<String>,
-    /// Progress (0.0 to 1.0).
     #[serde(default)]
-    pub progress: Option<f64>,
+    pub code: Option<String>,
 }
 
-impl JobStatusResponse {
-    /// Check if job is pending.
-    pub fn is_pending(&self) -> bool {
-        matches!(
-            self.status.to_lowercase().as_str(),
-            "pending" | "queued" | "running" | "executing"
-        )
-    }
+/// IQM Resonance job status enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JobStatusValue {
+    Waiting,
+    Processing,
+    Completed,
+    Failed,
+    Cancelled,
+}
 
-    /// Check if job completed successfully.
-    pub fn is_completed(&self) -> bool {
-        self.status.to_lowercase() == "completed" || self.status.to_lowercase() == "ready"
-    }
-
-    /// Check if job failed.
-    pub fn is_failed(&self) -> bool {
-        matches!(
-            self.status.to_lowercase().as_str(),
-            "failed" | "error" | "aborted"
-        )
-    }
-
-    /// Check if job was cancelled.
-    pub fn is_cancelled(&self) -> bool {
-        self.status.to_lowercase() == "cancelled"
+impl JobStatusValue {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
     }
 }
 
-/// Job result response.
+/// One block of measurement counts (one per submitted circuit).
 #[derive(Debug, Clone, Deserialize)]
-pub struct JobResultResponse {
-    /// Job identifier.
+pub struct MeasurementCounts {
+    /// Order of measurement keys; the bitstring keys in `counts`
+    /// concatenate one bit per entry in this list, in this order.
+    pub measurement_keys: Vec<String>,
+    /// Bitstring → count map.
+    pub counts: HashMap<String, u64>,
+}
+
+/// Job-size limits for a quantum computer.
+///
+/// Field names mirror the IQM Resonance JSON shape verbatim, hence the
+/// repeated `max_*` prefix — renaming them would break serde wire
+/// compatibility, so the lint is allowed locally.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::struct_field_names)]
+pub struct QcLimits {
+    pub max_instructions_per_circuit: u32,
+    pub max_executions_per_job: u64,
+    #[serde(default)]
+    pub max_circuits_per_job: Option<u32>,
+    #[serde(default)]
+    pub max_shots_per_circuit: Option<u32>,
+}
+
+/// Health snapshot for a quantum computer.
+#[derive(Debug, Clone, Deserialize)]
+pub struct QcHealthStatus {
+    pub healthy: bool,
+    pub updated_at: String,
+}
+
+/// Quantum computer entry from `GET /quantum-computers`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct QuantumComputer {
     pub id: String,
-    /// Final status.
-    pub status: String,
-    /// Measurement results.
-    #[serde(default)]
-    pub measurements: Option<Vec<MeasurementResult>>,
-    /// Aggregated counts.
-    #[serde(default)]
-    pub counts: Option<HashMap<String, u64>>,
-    /// Error message if failed.
-    #[serde(default)]
-    pub error: Option<String>,
-    /// Execution metadata.
-    #[serde(default)]
-    pub metadata: Option<JobMetadata>,
+    pub alias: String,
+    pub display_name: String,
+    pub station_control_version: String,
 }
 
-/// Single measurement result.
+/// Envelope for `GET /quantum-computers`.
 #[derive(Debug, Clone, Deserialize)]
-pub struct MeasurementResult {
-    /// Register name.
-    pub register: String,
-    /// Bit values as list of lists (shots x bits).
-    pub values: Vec<Vec<u8>>,
-}
-
-/// Job execution metadata.
-#[derive(Debug, Clone, Deserialize)]
-pub struct JobMetadata {
-    /// Execution time in milliseconds.
-    #[serde(default)]
-    pub execution_time_ms: Option<u64>,
-    /// Time spent in queue in seconds.
-    #[serde(default)]
-    pub queue_time_s: Option<u64>,
-    /// Backend used.
-    #[serde(default)]
-    pub backend: Option<String>,
-    /// Number of shots executed.
-    #[serde(default)]
-    pub shots: Option<u32>,
-    /// Calibration data snapshot timestamp.
-    #[serde(default)]
-    pub calibration_timestamp: Option<String>,
-}
-
-/// Backend information.
-#[derive(Debug, Clone, Deserialize)]
-pub struct BackendInfo {
-    /// Backend name.
-    pub name: String,
-    /// Number of qubits.
-    pub num_qubits: u32,
-    /// Backend status.
-    pub status: String,
-    /// Native gate set.
-    #[serde(default)]
-    pub native_gates: Vec<String>,
-    /// Connectivity (coupling map).
-    #[serde(default)]
-    pub connectivity: Vec<(u32, u32)>,
-    /// Maximum shots per job.
-    #[serde(default)]
-    pub max_shots: Option<u32>,
-    /// Maximum circuit depth.
-    #[serde(default)]
-    pub max_circuit_depth: Option<u32>,
-    /// Backend version/generation.
-    #[serde(default)]
-    pub generation: Option<String>,
-}
-
-impl BackendInfo {
-    /// Check if the backend is online.
-    pub fn is_online(&self) -> bool {
-        matches!(
-            self.status.to_lowercase().as_str(),
-            "online" | "available" | "ready"
-        )
-    }
+pub(crate) struct QuantumComputerList {
+    pub quantum_computers: Vec<QuantumComputer>,
 }
 
 #[cfg(test)]
@@ -410,26 +476,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_submit_request() {
-        let request = SubmitRequest::new("garnet", "OPENQASM 3.0; qubit[2] q;", 1000)
-            .with_name("test-job")
-            .with_tags(vec!["test".into()]);
+    fn submit_request_serializes_to_resonance_wire_format() {
+        // Captured from a real Resonance payload — the exact shape the
+        // adapter must produce.
+        let req = SubmitRequest::single(
+            IqmCircuit {
+                name: "probe-bell".into(),
+                instructions: vec![
+                    IqmInstruction::prx("QB1", std::f64::consts::FRAC_PI_2, 0.0),
+                    IqmInstruction::cz("QB1", "QB2"),
+                    IqmInstruction::measure("QB1", "c_0_0_0"),
+                    IqmInstruction::measure("QB2", "c_0_0_1"),
+                ],
+            },
+            1,
+        );
+        let json = serde_json::to_value(&req).unwrap();
 
-        let json = serde_json::to_string(&request).unwrap();
-        assert!(json.contains("garnet"));
-        assert!(json.contains("1000"));
+        assert_eq!(json["shots"], 1);
+        let circuits = json["circuits"].as_array().unwrap();
+        assert_eq!(circuits.len(), 1);
+        assert_eq!(circuits[0]["name"], "probe-bell");
+
+        let instructions = circuits[0]["instructions"].as_array().unwrap();
+        assert_eq!(instructions.len(), 4);
+
+        // prx — verify the args shape
+        assert_eq!(instructions[0]["name"], "prx");
+        assert_eq!(instructions[0]["locus"], serde_json::json!(["QB1"]));
+        assert!(instructions[0]["args"]["angle"].is_number());
+        assert_eq!(instructions[0]["args"]["phase"], 0.0);
+        assert!(instructions[0]["implementation"].is_null());
+
+        // cz — locus is a 2-tuple of qubit labels
+        assert_eq!(instructions[1]["name"], "cz");
+        assert_eq!(instructions[1]["locus"], serde_json::json!(["QB1", "QB2"]));
+
+        // measure — args carries the result key
+        assert_eq!(instructions[2]["name"], "measure");
+        assert_eq!(instructions[2]["args"]["key"], "c_0_0_0");
     }
 
     #[test]
-    fn test_job_status_response() {
-        let status = JobStatusResponse {
-            id: "job-123".into(),
-            status: "running".into(),
-            message: None,
-            progress: Some(0.5),
-        };
+    fn job_status_round_trip_via_lowercase_enum() {
+        // Resonance uses lowercase server names; the enum must accept them.
+        for (server, expected) in [
+            ("waiting", JobStatusValue::Waiting),
+            ("processing", JobStatusValue::Processing),
+            ("completed", JobStatusValue::Completed),
+            ("failed", JobStatusValue::Failed),
+            ("cancelled", JobStatusValue::Cancelled),
+        ] {
+            let parsed: JobStatusValue = serde_json::from_str(&format!("\"{server}\"")).unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
 
-        assert!(status.is_pending());
-        assert!(!status.is_completed());
+    #[test]
+    fn job_status_terminality() {
+        assert!(!JobStatusValue::Waiting.is_terminal());
+        assert!(!JobStatusValue::Processing.is_terminal());
+        assert!(JobStatusValue::Completed.is_terminal());
+        assert!(JobStatusValue::Failed.is_terminal());
+        assert!(JobStatusValue::Cancelled.is_terminal());
+    }
+
+    #[test]
+    fn measurement_counts_parses_resonance_artifact_shape() {
+        // From a real Sirius job's measurement_counts artifact.
+        let raw = r#"[
+            {
+              "measurement_keys": ["c_0_0_0"],
+              "counts": {"0": 7, "1": 3}
+            }
+        ]"#;
+        let parsed: Vec<MeasurementCounts> = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].measurement_keys, vec!["c_0_0_0"]);
+        assert_eq!(parsed[0].counts.get("0").copied(), Some(7));
+        assert_eq!(parsed[0].counts.get("1").copied(), Some(3));
     }
 }

--- a/adapters/arvak-adapter-iqm/src/backend.rs
+++ b/adapters/arvak-adapter-iqm/src/backend.rs
@@ -1,4 +1,18 @@
-//! IQM backend implementation.
+//! IQM Resonance backend (HAL-thin).
+//!
+//! Translates an already-IQM-native [`arvak_ir::Circuit`] into the
+//! Resonance v1 wire format, submits it, and surfaces the
+//! `measurement_counts` artifact back through [`ExecutionResult`].
+//!
+//! # Layering
+//!
+//! Per the HAL contract, this backend does *not* transpile. It
+//! advertises its native gate set (`prx`, `cz` plus `measure`) via
+//! [`Capabilities`], rejects non-native instructions in `validate()`,
+//! and is otherwise a thin wire translator. Lowering arbitrary user
+//! circuits into PRX/CZ is `arvak-compile`'s responsibility — the
+//! same pattern the IBM Heron, AQT, Quantinuum and Quandela adapters
+//! follow.
 
 use async_trait::async_trait;
 use rustc_hash::FxHashMap;
@@ -13,21 +27,25 @@ use arvak_hal::{
     ValidationResult,
 };
 use arvak_ir::Circuit;
+use arvak_ir::gate::{GateKind, StandardGate};
+use arvak_ir::instruction::InstructionKind;
 
-use crate::api::{BackendInfo, IqmClient, SubmitRequest};
+use crate::api::{
+    IqmCircuit, IqmClient, IqmInstruction, JobStatusValue, MeasurementCounts, SubmitRequest,
+};
 use crate::error::{IqmError, IqmResult};
 
-/// Default IQM Resonance API endpoint.
-pub const DEFAULT_ENDPOINT: &str = "https://cocos.resonance.meetiqm.com/api/v1";
+/// Default IQM Resonance v1 API endpoint.
+pub const DEFAULT_ENDPOINT: &str = "https://resonance.iqm.tech/api/v1";
 
-/// Default target backend (Garnet - IQM's 20-qubit device).
+/// Default target backend (Garnet — IQM's 20-qubit Resonance device).
 pub const DEFAULT_BACKEND: &str = "garnet";
 
 /// Maximum number of cached jobs before evicting completed entries.
 const MAX_CACHED_JOBS: usize = 10_000;
 
-/// How long to cache backend info before refreshing from the API.
-const BACKEND_INFO_TTL: Duration = Duration::from_secs(5 * 60);
+/// How long to cache QC health data before re-querying.
+const HEALTH_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Job cache entry.
 struct CachedJob {
@@ -35,23 +53,25 @@ struct CachedJob {
     result: Option<ExecutionResult>,
 }
 
-/// IQM quantum computer backend.
+/// IQM Resonance backend.
 ///
-/// This backend connects to IQM quantum computers via the Resonance cloud API.
-/// It supports IQM's native gate set (PRX, CZ) and star topology.
+/// One [`IqmBackend`] instance targets a single quantum computer
+/// alias (`garnet`, `emerald`, etc.). Multiple instances may coexist
+/// in the same process — `Backend::name()` returns `"iqm_<target>"`
+/// so callers can tell them apart.
 pub struct IqmBackend {
     /// Backend configuration.
     config: BackendConfig,
     /// API client.
     client: IqmClient,
-    /// Target quantum computer name.
+    /// Target quantum computer alias or UUID.
     target: String,
-    /// Cached capabilities (HAL Contract v2: sync introspection).
+    /// Cached capabilities (HAL contract v2: sync introspection).
     capabilities: Capabilities,
     /// Cached job information.
     jobs: Arc<Mutex<FxHashMap<String, CachedJob>>>,
-    /// Cached backend info with fetch timestamp for TTL-based refresh.
-    backend_info: Arc<Mutex<Option<(BackendInfo, Instant)>>>,
+    /// Cached health snapshot for `availability()`.
+    health: Arc<Mutex<Option<(bool, Instant)>>>,
 }
 
 impl IqmBackend {
@@ -71,12 +91,12 @@ impl IqmBackend {
     /// Create a backend targeting a specific IQM device.
     ///
     /// `Backend::name()` will return `"iqm_<target>"` so multiple IQM
-    /// instances in the same process remain distinguishable to callers.
+    /// instances in the same process remain distinguishable.
     pub fn with_target(target: impl Into<String>) -> IqmResult<Self> {
         let token = std::env::var("IQM_TOKEN").map_err(|_| IqmError::MissingToken)?;
         let target_str: String = target.into();
 
-        let mut config = BackendConfig::new(format!("iqm_{}", target_str))
+        let mut config = BackendConfig::new(format!("iqm_{target_str}"))
             .with_endpoint(DEFAULT_ENDPOINT)
             .with_token(&token);
 
@@ -94,7 +114,7 @@ impl IqmBackend {
         target: impl Into<String>,
     ) -> IqmResult<Self> {
         let target_str: String = target.into();
-        let mut config = BackendConfig::new(format!("iqm_{}", target_str))
+        let mut config = BackendConfig::new(format!("iqm_{target_str}"))
             .with_endpoint(endpoint)
             .with_token(token);
 
@@ -107,24 +127,19 @@ impl IqmBackend {
 
     /// Create a backend authenticated via OIDC (LUMI Helmi / LRZ).
     ///
-    /// Reads a cached OIDC token (from a prior interactive `arvak auth
-    /// login` session) and uses it as the bearer for IQM Resonance
-    /// REST calls. If no valid cached token is found, returns an
-    /// authentication error pointing the user at the login command.
-    ///
-    /// The endpoint URL is required and must be provided by the
-    /// caller — LUMI's URL is delivered via the `HELMI_CORTEX_URL`
-    /// environment variable inside the LUMI module environment; LRZ
-    /// users get theirs from the LRZ documentation.
+    /// Reads a cached OIDC token (from a prior interactive
+    /// `arvak auth login` session) and uses it as the Bearer for
+    /// Resonance REST calls. Returns an authentication error if no
+    /// valid cached token is available, pointing the user at the
+    /// login command.
     ///
     /// # Limitation
     ///
     /// The bearer token is fetched once at construction. For very
-    /// long-running jobs (≫ 1 hour) that exceed the OIDC access
-    /// token lifetime, the in-flight HTTP call may fail with 401 and
-    /// the user must reconstruct the backend (which triggers
-    /// auto-refresh from the cached refresh token via `OidcAuth`).
-    /// A proper auto-refresh path is future work.
+    /// long-running jobs (≫ 1 hour) that exceed the OIDC access token
+    /// lifetime, the in-flight HTTP call may fail with 401 and the
+    /// caller must reconstruct the backend (which triggers
+    /// auto-refresh from the cached refresh token via [`OidcAuth`]).
     pub fn with_oidc(
         config: OidcConfig,
         target: impl Into<String>,
@@ -133,16 +148,10 @@ impl IqmBackend {
         let auth = OidcAuth::new(config)
             .map_err(|e| IqmError::AuthFailed(format!("OIDC handler init failed: {e}")))?;
 
-        // Sync block on the async get_token. OidcAuth tries cache → refresh
-        // and only fails if no valid path is available.
         let rt = tokio::runtime::Handle::try_current().ok();
         let token = if let Some(handle) = rt {
-            // We're already inside a tokio runtime (PyO3 wrapper path) —
-            // block_in_place + handle.block_on, or just use the handle.
-            // Safest: spawn a temporary runtime on the current thread.
             tokio::task::block_in_place(|| handle.block_on(auth.get_token()))
         } else {
-            // Standalone Rust caller — build a private runtime.
             let private_rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -170,18 +179,17 @@ impl IqmBackend {
 
         let client = IqmClient::new(endpoint, token)?;
 
-        // Per-target qubit counts for known IQM Resonance machines.
-        // Falls back to 20 (Garnet, the most common default) for unknown
-        // targets so we stay conservative on capacity reporting. The
-        // adapter's TTL-cached `backend_info` query overrides this at
-        // runtime once the HTTP API answers — these defaults are only
-        // used until the first successful availability/backend-info call.
+        // Per-target qubit counts for known Resonance machines (as of
+        // 2026-06-25). The first successful availability() call may
+        // refresh these via the live API; the defaults here cover the
+        // construction-time `capabilities()` call without requiring
+        // a network round-trip.
         let num_qubits = match target.to_ascii_lowercase().as_str() {
             "sirius" => 16,
             "emerald" | "crystal" => 54,
             _ => 20,
         };
-        let capabilities = Capabilities::iqm(&target, num_qubits);
+        let capabilities = Capabilities::iqm(format!("iqm_{target}"), num_qubits);
 
         Ok(Self {
             config,
@@ -189,7 +197,7 @@ impl IqmBackend {
             target,
             capabilities,
             jobs: Arc::new(Mutex::new(FxHashMap::default())),
-            backend_info: Arc::new(Mutex::new(None)),
+            health: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -198,74 +206,203 @@ impl IqmBackend {
         &self.target
     }
 
-    /// Fetch and cache backend information, refreshing if stale.
-    async fn fetch_backend_info(&self) -> IqmResult<BackendInfo> {
-        // Check cache first; refresh if older than TTL.
+    /// Fetch and cache health, refreshing if stale.
+    async fn fetch_health(&self) -> IqmResult<bool> {
         {
-            let cache = self.backend_info.lock().await;
-            if let Some((ref info, fetched_at)) = *cache {
-                if fetched_at.elapsed() < BACKEND_INFO_TTL {
-                    return Ok(info.clone());
+            let cache = self.health.lock().await;
+            if let Some((healthy, fetched_at)) = *cache {
+                if fetched_at.elapsed() < HEALTH_TTL {
+                    return Ok(healthy);
                 }
             }
         }
 
-        // Fetch from API
-        let info = self.client.get_backend_info(&self.target).await?;
+        let info = self.client.get_qc_health(&self.target).await?;
 
-        // Cache it with current timestamp
         {
-            let mut cache = self.backend_info.lock().await;
-            *cache = Some((info.clone(), Instant::now()));
+            let mut cache = self.health.lock().await;
+            *cache = Some((info.healthy, Instant::now()));
         }
 
-        Ok(info)
+        Ok(info.healthy)
     }
 
-    /// Convert circuit to QASM3 string.
-    fn circuit_to_qasm(&self, circuit: &Circuit) -> IqmResult<String> {
-        arvak_qasm3::emit(circuit).map_err(|e| IqmError::QasmError(e.to_string()))
-    }
-
-    /// Convert IQM measurement results to Counts.
+    /// Translate an Arvak IR circuit into the IQM Resonance v1 wire
+    /// format.
     ///
-    /// IQM returns per-shot bit arrays with array index i = measured qubit i
-    /// (the order qubits appear in the measurement instruction). The HAL
-    /// Contract bit order puts qubit 0 in the RIGHTMOST character
-    /// (OpenQASM 3 / Qiskit convention), so each shot array is reversed.
-    fn measurements_to_counts(measurements: &[crate::api::MeasurementResult]) -> Counts {
+    /// The circuit must already be in IQM-native form — only `PRX(angle,
+    /// phase)`, `CZ`, and `Measure` instructions are accepted; anything
+    /// else raises `InvalidCircuit`. Use `arvak-compile` with an IQM
+    /// target to decompose arbitrary user circuits before submission.
+    ///
+    /// Qubit labels follow the Resonance convention: `QubitId(i)` maps
+    /// to `"QB{i+1}"`. Measurement results are keyed `c_{circuit_idx}_
+    /// {classical_register_idx}_{bit_idx}` to match the format we
+    /// observed in real Sirius / Garnet jobs.
+    fn circuit_to_iqm(&self, circuit: &Circuit) -> Result<IqmCircuit, HalError> {
+        let mut instructions = Vec::new();
+        let mut measure_idx: usize = 0;
+
+        for (_, inst) in circuit.dag().topological_ops() {
+            match &inst.kind {
+                InstructionKind::Gate(gate) => {
+                    let name = gate.name();
+                    let qubit_labels: Vec<String> = inst
+                        .qubits
+                        .iter()
+                        .map(|q| format!("QB{}", q.0 + 1))
+                        .collect();
+
+                    match &gate.kind {
+                        GateKind::Standard(StandardGate::PRX(theta, phi)) => {
+                            let angle = theta.as_f64().ok_or_else(|| {
+                                HalError::InvalidCircuit(
+                                    "PRX angle parameter not resolvable to a constant; \
+                                     IQM Resonance requires concrete angles at submission. \
+                                     Bind symbols via arvak.compile() before submission."
+                                        .into(),
+                                )
+                            })?;
+                            let phase = phi.as_f64().ok_or_else(|| {
+                                HalError::InvalidCircuit(
+                                    "PRX phase parameter not resolvable to a constant; \
+                                     IQM Resonance requires concrete angles at submission. \
+                                     Bind symbols via arvak.compile() before submission."
+                                        .into(),
+                                )
+                            })?;
+                            instructions.push(IqmInstruction::prx(&qubit_labels[0], angle, phase));
+                        }
+                        GateKind::Standard(StandardGate::CZ) => {
+                            if qubit_labels.len() != 2 {
+                                return Err(HalError::InvalidCircuit(format!(
+                                    "CZ requires 2 qubits, got {}",
+                                    qubit_labels.len()
+                                )));
+                            }
+                            instructions
+                                .push(IqmInstruction::cz(&qubit_labels[0], &qubit_labels[1]));
+                        }
+                        _ => {
+                            return Err(HalError::InvalidCircuit(format!(
+                                "{} is not in the IQM native gate set ({{prx, cz}}). \
+                                 Compile with arvak.compile(target=\"iqm_{}\") to decompose \
+                                 before submission.",
+                                name, self.target
+                            )));
+                        }
+                    }
+                }
+                InstructionKind::Measure => {
+                    for q in &inst.qubits {
+                        let qubit_label = format!("QB{}", q.0 + 1);
+                        // Mirror the Resonance UI key shape we observed in
+                        // real jobs: c_{circuit_idx}_0_{measure_idx}.
+                        let key = format!("c_0_0_{measure_idx}");
+                        instructions.push(IqmInstruction::measure(&qubit_label, &key));
+                        measure_idx += 1;
+                    }
+                }
+                InstructionKind::Barrier => {
+                    // Barriers are scheduling hints, not native ops on
+                    // Resonance — drop them silently.
+                }
+                InstructionKind::Reset => {
+                    return Err(HalError::InvalidCircuit(
+                        "Reset is not supported by IQM Resonance circuit jobs.".into(),
+                    ));
+                }
+                InstructionKind::Delay { .. } => {
+                    return Err(HalError::InvalidCircuit(
+                        "Delay instructions are not yet supported by this adapter.".into(),
+                    ));
+                }
+                InstructionKind::Shuttle { .. } => {
+                    return Err(HalError::InvalidCircuit(
+                        "Shuttle instructions are not part of the IQM Resonance \
+                         instruction set."
+                            .into(),
+                    ));
+                }
+                InstructionKind::NoiseChannel { .. } => {
+                    return Err(HalError::InvalidCircuit(
+                        "Noise channels are not submittable to live IQM hardware.".into(),
+                    ));
+                }
+            }
+        }
+
+        if instructions.is_empty() {
+            return Err(HalError::InvalidCircuit(
+                "Empty circuit (no IQM-native instructions found).".into(),
+            ));
+        }
+
+        Ok(IqmCircuit {
+            name: format!("arvak-{}", uuid_short()),
+            instructions,
+        })
+    }
+
+    /// Convert Resonance measurement_counts → HAL `Counts`.
+    ///
+    /// Resonance returns a per-circuit list of `{measurement_keys, counts}`
+    /// blocks where the count keys are bitstrings concatenated in
+    /// `measurement_keys` order. The HAL contract puts qubit 0 in the
+    /// RIGHTMOST character of the count key (OpenQASM 3 / Qiskit
+    /// convention), so we re-key by reversing the string.
+    fn measurement_counts_to_counts(blocks: &[MeasurementCounts]) -> Counts {
         let mut counts = Counts::new();
 
-        // Find the classical register (usually "c" or "meas")
-        if let Some(result) = measurements.first() {
-            for shot in &result.values {
-                let bitstring: String = shot
-                    .iter()
-                    .rev()
-                    .map(|&b| if b != 0 { '1' } else { '0' })
-                    .collect();
-                // Counts::insert accumulates: repeated bitstrings correctly increment the count.
-                counts.insert(bitstring, 1);
+        // Single-circuit submission ⇒ first (and only) block.
+        if let Some(block) = blocks.first() {
+            for (bitstring, n) in &block.counts {
+                // Resonance bitstring is in measurement_keys order, which
+                // is the order measure-instructions appear in the circuit.
+                // We submitted them in c_0_0_0, c_0_0_1, ... matching
+                // qubit-id order, so reversal lands qubit 0 on the right.
+                let normalized: String = bitstring.chars().rev().collect();
+                counts.insert(normalized, *n);
             }
         }
 
         counts
     }
 
-    /// Convert pre-aggregated counts from API response.
-    ///
-    /// Key characters use the same bit order as the per-shot value arrays
-    /// (index i = measured qubit i), so they are reversed to the HAL
-    /// Contract order (qubit 0 rightmost) for consistency with
-    /// `measurements_to_counts`.
-    fn api_counts_to_counts(api_counts: &std::collections::HashMap<String, u64>) -> Counts {
-        let mut counts = Counts::new();
-        for (bitstring, count) in api_counts {
-            let normalized: String = bitstring.chars().rev().collect();
-            counts.insert(normalized, *count);
+    /// Map a Resonance status enum to the HAL `JobStatus` enum.
+    fn map_status(value: JobStatusValue, errors: Option<&Vec<crate::api::JobError>>) -> JobStatus {
+        match value {
+            JobStatusValue::Waiting => JobStatus::Queued,
+            JobStatusValue::Processing => JobStatus::Running,
+            JobStatusValue::Completed => JobStatus::Completed,
+            JobStatusValue::Cancelled => JobStatus::Cancelled,
+            JobStatusValue::Failed => {
+                let message = errors
+                    .and_then(|es| {
+                        es.iter()
+                            .find_map(|e| e.message.as_deref())
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| "IQM Resonance reported failed".into());
+                JobStatus::Failed(message)
+            }
         }
-        counts
     }
+}
+
+/// Short, unique-enough circuit-name suffix for the Resonance UI.
+///
+/// Avoids a `uuid` dependency for what is purely a display label —
+/// the API does not key off it.
+fn uuid_short() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    format!("{nanos:x}-{n:x}")
 }
 
 #[async_trait]
@@ -280,19 +417,16 @@ impl Backend for IqmBackend {
 
     #[instrument(skip(self))]
     async fn availability(&self) -> HalResult<BackendAvailability> {
-        match self.fetch_backend_info().await {
-            Ok(info) => {
-                if info.is_online() {
-                    Ok(BackendAvailability {
-                        is_available: true,
-                        queue_depth: None,
-                        estimated_wait: None,
-                        status_message: None,
-                    })
-                } else {
-                    Ok(BackendAvailability::unavailable("backend offline"))
-                }
-            }
+        match self.fetch_health().await {
+            Ok(true) => Ok(BackendAvailability {
+                is_available: true,
+                queue_depth: None,
+                estimated_wait: None,
+                status_message: None,
+            }),
+            Ok(false) => Ok(BackendAvailability::unavailable(
+                "Resonance reports QC unhealthy",
+            )),
             Err(e) => {
                 debug!("Backend availability check failed: {}", e);
                 Ok(BackendAvailability::unavailable(e.to_string()))
@@ -313,13 +447,21 @@ impl Backend for IqmBackend {
             ));
         }
 
-        // Check gate set support
+        // Native-gate enforcement: only `prx`, `cz`, and `measure` are
+        // accepted on the wire. The HAL contract puts the responsibility
+        // for lowering arbitrary gates on `arvak-compile`, not on the
+        // adapter.
         let gate_set = &caps.gate_set;
         for (_, inst) in circuit.dag().topological_ops() {
             if let Some(gate) = inst.as_gate() {
                 let name = gate.name();
                 if !gate_set.contains(name) {
-                    reasons.push(format!("Unsupported gate: {}", name));
+                    reasons.push(format!(
+                        "Unsupported gate: {name} (IQM Resonance native set is \
+                         {{prx, cz}}; compile via arvak.compile(target=\"iqm_{}\") \
+                         first)",
+                        self.target
+                    ));
                     break;
                 }
             }
@@ -339,7 +481,6 @@ impl Backend for IqmBackend {
         shots: u32,
         parameters: Option<&std::collections::HashMap<String, f64>>,
     ) -> HalResult<JobId> {
-        // DEBT-25: reject non-empty parameter bindings (not yet supported).
         if parameters.is_some_and(|p| !p.is_empty()) {
             return Err(HalError::Unsupported(
                 "IQM backend does not support runtime parameter binding".into(),
@@ -353,7 +494,6 @@ impl Backend for IqmBackend {
             shots
         );
 
-        // Validate circuit size
         let caps = self.capabilities();
         if circuit.num_qubits() > caps.num_qubits as usize {
             return Err(HalError::CircuitTooLarge(format!(
@@ -363,8 +503,6 @@ impl Backend for IqmBackend {
                 caps.num_qubits
             )));
         }
-
-        // Validate shots
         if shots > caps.max_shots {
             return Err(HalError::InvalidShots(format!(
                 "Requested {} shots but maximum is {}",
@@ -372,34 +510,27 @@ impl Backend for IqmBackend {
             )));
         }
 
-        // Convert circuit to QASM3
-        let qasm = self
-            .circuit_to_qasm(circuit)
-            .map_err(|e| HalError::Backend(e.to_string()))?;
-        debug!("Generated QASM:\n{}", qasm);
+        let iqm_circuit = self.circuit_to_iqm(circuit)?;
+        debug!(
+            "Translated to IQM wire format ({} instructions)",
+            iqm_circuit.instructions.len()
+        );
+        let request = SubmitRequest::single(iqm_circuit, shots);
 
-        // Create submit request
-        let request = SubmitRequest::new(&self.target, qasm, shots);
-
-        // Submit to API
         let response = self
             .client
-            .submit_job(&request)
+            .submit_circuit(&self.target, &request)
             .await
             .map_err(|e| HalError::Backend(e.to_string()))?;
 
         let job_id = JobId::new(&response.id);
         info!("Job submitted: {}", job_id);
 
-        // Cache job info, evicting completed entries if the cache is full.
-        // If no terminal entries exist, evict an arbitrary active entry to
-        // prevent unbounded memory growth.
         let job = Job::new(job_id.clone(), shots).with_backend(&self.target);
         {
             let mut jobs = self.jobs.lock().await;
             if jobs.len() >= MAX_CACHED_JOBS {
                 jobs.retain(|_, j| !j.job.status.is_terminal());
-                // If retain did not free any space, evict any entry to bound memory.
                 if jobs.len() >= MAX_CACHED_JOBS {
                     tracing::warn!(
                         capacity = MAX_CACHED_JOBS,
@@ -419,28 +550,13 @@ impl Backend for IqmBackend {
 
     #[instrument(skip(self))]
     async fn status(&self, job_id: &JobId) -> HalResult<JobStatus> {
-        let response = self
-            .client
-            .get_job_status(&job_id.0)
-            .await
-            .map_err(|e| match e {
-                IqmError::JobNotFound(_) => HalError::JobNotFound(job_id.0.clone()),
-                _ => HalError::Backend(e.to_string()),
-            })?;
+        let response = self.client.get_job(&job_id.0).await.map_err(|e| match e {
+            IqmError::JobNotFound(_) => HalError::JobNotFound(job_id.0.clone()),
+            _ => HalError::Backend(e.to_string()),
+        })?;
 
-        let status = if response.is_completed() {
-            JobStatus::Completed
-        } else if response.is_failed() {
-            JobStatus::Failed(response.message.unwrap_or_default())
-        } else if response.is_cancelled() {
-            JobStatus::Cancelled
-        } else if response.status.to_lowercase() == "running" {
-            JobStatus::Running
-        } else {
-            JobStatus::Queued
-        };
+        let status = Self::map_status(response.status, response.errors.as_ref());
 
-        // Update cache
         {
             let mut jobs = self.jobs.lock().await;
             if let Some(cached) = jobs.get_mut(&job_id.0) {
@@ -453,7 +569,6 @@ impl Backend for IqmBackend {
 
     #[instrument(skip(self))]
     async fn result(&self, job_id: &JobId) -> HalResult<ExecutionResult> {
-        // Check cache first
         {
             let jobs = self.jobs.lock().await;
             if let Some(cached) = jobs.get(&job_id.0) {
@@ -463,53 +578,62 @@ impl Backend for IqmBackend {
             }
         }
 
-        // Fetch from API
-        let response = self
-            .client
-            .get_job_result(&job_id.0)
-            .await
-            .map_err(|e| match e {
-                IqmError::JobNotFound(_) => HalError::JobNotFound(job_id.0.clone()),
-                _ => HalError::Backend(e.to_string()),
-            })?;
+        // Confirm the job is actually terminal before fetching the
+        // counts artifact — otherwise the artifact may not yet exist.
+        let job = self.client.get_job(&job_id.0).await.map_err(|e| match e {
+            IqmError::JobNotFound(_) => HalError::JobNotFound(job_id.0.clone()),
+            _ => HalError::Backend(e.to_string()),
+        })?;
 
-        // Check for errors
-        if let Some(error) = response.error {
-            return Err(HalError::JobFailed(error));
-        }
-
-        // Convert results
-        let counts = if let Some(ref api_counts) = response.counts {
-            Self::api_counts_to_counts(api_counts)
-        } else if let Some(ref measurements) = response.measurements {
-            Self::measurements_to_counts(measurements)
-        } else {
-            return Err(HalError::JobFailed("No measurement results".into()));
-        };
-
-        let shots = response
-            .metadata
-            .as_ref()
-            .and_then(|m| m.shots)
-            .unwrap_or(counts.total_shots() as u32);
-
-        let mut result = ExecutionResult::new(counts, shots);
-
-        // Add execution time if available
-        if let Some(ref metadata) = response.metadata {
-            if let Some(time_ms) = metadata.execution_time_ms {
-                result = result.with_execution_time(time_ms);
+        match job.status {
+            JobStatusValue::Completed => {}
+            JobStatusValue::Failed => {
+                let msg = job
+                    .errors
+                    .as_ref()
+                    .and_then(|es| {
+                        es.iter()
+                            .find_map(|e| e.message.as_deref())
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| "IQM Resonance reported failed".into());
+                return Err(HalError::JobFailed(msg));
             }
-
-            // Add metadata
-            result = result.with_metadata(serde_json::json!({
-                "backend": metadata.backend,
-                "queue_time_s": metadata.queue_time_s,
-                "calibration_timestamp": metadata.calibration_timestamp,
-            }));
+            JobStatusValue::Cancelled => {
+                return Err(HalError::JobFailed("job was cancelled".into()));
+            }
+            JobStatusValue::Waiting | JobStatusValue::Processing => {
+                return Err(HalError::JobFailed(format!(
+                    "job {} is not yet terminal (status: {:?})",
+                    job_id.0, job.status
+                )));
+            }
         }
 
-        // Cache result
+        let blocks = self
+            .client
+            .get_measurement_counts(&job_id.0)
+            .await
+            .map_err(|e| HalError::Backend(e.to_string()))?;
+
+        let counts = Self::measurement_counts_to_counts(&blocks);
+        let total = counts.total_shots() as u32;
+        if total == 0 {
+            return Err(HalError::JobFailed(
+                "No measurement counts in artifact (empty result)".into(),
+            ));
+        }
+
+        let mut result = ExecutionResult::new(counts, total);
+        if let Some(rt_ms) = job.runtime_ms {
+            result = result.with_execution_time(rt_ms);
+        }
+        result = result.with_metadata(serde_json::json!({
+            "backend": format!("iqm_{}", self.target),
+            "iqm_job_id": job_id.0.clone(),
+            "runtime_ms": job.runtime_ms,
+        }));
+
         {
             let mut jobs = self.jobs.lock().await;
             if let Some(cached) = jobs.get_mut(&job_id.0) {
@@ -531,7 +655,6 @@ impl Backend for IqmBackend {
                 _ => HalError::Backend(e.to_string()),
             })?;
 
-        // Update cache
         {
             let mut jobs = self.jobs.lock().await;
             if let Some(cached) = jobs.get_mut(&job_id.0) {
@@ -553,6 +676,8 @@ impl BackendFactory for IqmBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arvak_ir::QubitId;
+    use arvak_ir::parameter::ParameterExpression;
 
     #[test]
     fn test_backend_config() {
@@ -567,26 +692,145 @@ mod tests {
     }
 
     #[test]
-    fn test_measurements_to_counts_bit_order() {
-        // HAL Contract conformance: qubit 0 is the RIGHTMOST character.
-        // One shot with q0=1, q1=0 (array index i = qubit i) must yield "01".
-        let measurements = vec![crate::api::MeasurementResult {
-            register: "c".into(),
-            values: vec![vec![1, 0], vec![0, 0]],
-        }];
-        let counts = IqmBackend::measurements_to_counts(&measurements);
-        assert_eq!(counts.get("01"), 1, "q0=1 must be the rightmost bit");
-        assert_eq!(counts.get("00"), 1);
-        assert_eq!(counts.get("10"), 0);
+    fn capabilities_advertise_iqm_native_set() {
+        let backend =
+            IqmBackend::with_credentials("https://example/api/v1", "test-token", "garnet")
+                .expect("constructs");
+
+        let caps = backend.capabilities();
+        assert!(caps.gate_set.contains("prx"));
+        assert!(caps.gate_set.contains("cz"));
+        assert!(!caps.gate_set.contains("h"));
+        assert!(!caps.gate_set.contains("cx"));
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_non_native_gate_with_helpful_message() {
+        let backend =
+            IqmBackend::with_credentials("https://example/api/v1", "test-token", "garnet").unwrap();
+
+        // Build a circuit with H (not native) — must be rejected.
+        let mut c = Circuit::with_size("h-test", 1, 1);
+        c.h(QubitId(0)).unwrap();
+        let vr = backend.validate(&c).await.unwrap();
+        match vr {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons
+                        .iter()
+                        .any(|r| r.contains("Unsupported gate: h") && r.contains("arvak.compile")),
+                    "expected helpful reject reason, got {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_accepts_native_prx_cz_circuit() {
+        let backend =
+            IqmBackend::with_credentials("https://example/api/v1", "test-token", "garnet").unwrap();
+
+        let mut c = Circuit::with_size("native-bell", 2, 2);
+        // PRX(π/2, π) on q0 — IQM-native form of Hadamard.
+        c.prx(
+            ParameterExpression::Constant(std::f64::consts::FRAC_PI_2),
+            ParameterExpression::Constant(std::f64::consts::PI),
+            QubitId(0),
+        )
+        .unwrap();
+        c.cz(QubitId(0), QubitId(1)).unwrap();
+        c.measure(QubitId(0), arvak_ir::ClbitId(0)).unwrap();
+        c.measure(QubitId(1), arvak_ir::ClbitId(1)).unwrap();
+
+        let vr = backend.validate(&c).await.unwrap();
+        assert!(matches!(vr, ValidationResult::Valid), "got {vr:?}");
     }
 
     #[test]
-    fn test_api_counts_bit_order() {
-        // Pre-aggregated API keys use array order (q0 first) and must be
-        // reversed to the HAL Contract order (q0 rightmost).
-        let mut api_counts = std::collections::HashMap::new();
-        api_counts.insert("10".to_string(), 7u64); // q0=1, q1=0
-        let counts = IqmBackend::api_counts_to_counts(&api_counts);
-        assert_eq!(counts.get("01"), 7);
+    fn circuit_to_iqm_emits_resonance_wire_format() {
+        let backend =
+            IqmBackend::with_credentials("https://example/api/v1", "test-token", "garnet").unwrap();
+
+        let mut c = Circuit::with_size("native-bell", 2, 2);
+        c.prx(
+            ParameterExpression::Constant(std::f64::consts::FRAC_PI_2),
+            ParameterExpression::Constant(std::f64::consts::PI),
+            QubitId(0),
+        )
+        .unwrap();
+        c.cz(QubitId(0), QubitId(1)).unwrap();
+        c.measure(QubitId(0), arvak_ir::ClbitId(0)).unwrap();
+        c.measure(QubitId(1), arvak_ir::ClbitId(1)).unwrap();
+
+        let translated = backend.circuit_to_iqm(&c).expect("translates");
+        assert_eq!(translated.instructions.len(), 4);
+
+        // prx on QB1
+        assert_eq!(translated.instructions[0].name, "prx");
+        assert_eq!(translated.instructions[0].locus, vec!["QB1".to_string()]);
+
+        // cz QB1, QB2
+        assert_eq!(translated.instructions[1].name, "cz");
+        assert_eq!(
+            translated.instructions[1].locus,
+            vec!["QB1".to_string(), "QB2".to_string()]
+        );
+
+        // measure QB1 c_0_0_0
+        assert_eq!(translated.instructions[2].name, "measure");
+        assert_eq!(translated.instructions[2].args["key"], "c_0_0_0");
+
+        // measure QB2 c_0_0_1
+        assert_eq!(translated.instructions[3].name, "measure");
+        assert_eq!(translated.instructions[3].args["key"], "c_0_0_1");
+    }
+
+    #[test]
+    fn measurement_counts_bit_order_matches_hal_contract() {
+        // q0 measured first → "c_0_0_0", q1 second → "c_0_0_1".
+        // Resonance keys are "<q0_bit><q1_bit>" (measurement_keys order).
+        // HAL contract puts q0 on the right; we reverse.
+        let mut counts_in = std::collections::HashMap::new();
+        counts_in.insert("10".to_string(), 7u64); // q0=1, q1=0
+        counts_in.insert("01".to_string(), 3u64); // q0=0, q1=1
+        let blocks = vec![MeasurementCounts {
+            measurement_keys: vec!["c_0_0_0".into(), "c_0_0_1".into()],
+            counts: counts_in,
+        }];
+        let out = IqmBackend::measurement_counts_to_counts(&blocks);
+        assert_eq!(out.get("01"), 7);
+        assert_eq!(out.get("10"), 3);
+    }
+
+    #[test]
+    fn map_status_covers_all_resonance_states() {
+        assert!(matches!(
+            IqmBackend::map_status(JobStatusValue::Waiting, None),
+            JobStatus::Queued
+        ));
+        assert!(matches!(
+            IqmBackend::map_status(JobStatusValue::Processing, None),
+            JobStatus::Running
+        ));
+        assert!(matches!(
+            IqmBackend::map_status(JobStatusValue::Completed, None),
+            JobStatus::Completed
+        ));
+        assert!(matches!(
+            IqmBackend::map_status(JobStatusValue::Cancelled, None),
+            JobStatus::Cancelled
+        ));
+        let failed = IqmBackend::map_status(
+            JobStatusValue::Failed,
+            Some(&vec![crate::api::JobError {
+                message: Some("calibration drift".into()),
+                code: None,
+            }]),
+        );
+        match failed {
+            JobStatus::Failed(msg) => assert!(msg.contains("calibration drift")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 }

--- a/adapters/arvak-adapter-iqm/src/backend.rs
+++ b/adapters/arvak-adapter-iqm/src/backend.rs
@@ -400,8 +400,7 @@ fn uuid_short() -> String {
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_nanos() as u64);
     format!("{nanos:x}-{n:x}")
 }
 


### PR DESCRIPTION
## Summary

IQM retired the `cocos.resonance.meetiqm.com/api/v1` interface this adapter targeted. New endpoint is `https://resonance.iqm.tech/api/v1` and the surface is materially different — different URL structure, different submission body, different status enum, separate artifact endpoint for measurement counts. This PR rewrites the adapter against the new surface.

The previous "Authentication failed — network restrictions" message was a misleading deprecation notice from the old endpoint, not an IP allowlist as I initially thought. The new endpoint works fine with a Bearer token + non-empty User-Agent (Cloudflare 1010-blocks bare HTTP clients).

## What changed

**`adapters/arvak-adapter-iqm/src/api.rs`** — full rewrite against the v1 OpenAPI surface:

| New type / method | Purpose |
|---|---|
| `SubmitRequest`, `IqmCircuit`, `IqmInstruction` | wire-format types matching the IQM IR JSON shape (`{circuits: [{name, instructions: [{name, locus, args, implementation}]}], shots}`) |
| `IqmInstruction::prx / cz / measure` | builders that mirror the live shapes (`prx(q, angle, phase)`, `cz(q1, q2)`, `measure(q, key)`) |
| `Job`, `JobStatusValue` enum | matches Resonance status enum `{waiting, processing, completed, failed, cancelled}` |
| `MeasurementCounts` | `{measurement_keys, counts}` block shape from `/artifacts/measurement_counts` |
| `submit_circuit`, `get_job`, `get_measurement_counts`, `cancel_job`, `get_qc_limits`, `get_qc_health`, `list_quantum_computers` | new endpoint methods |
| User-Agent header | always `arvak-adapter-iqm/1.0` so Cloudflare lets requests through |

**`adapters/arvak-adapter-iqm/src/backend.rs`**:
- `DEFAULT_ENDPOINT` → `https://resonance.iqm.tech/api/v1`
- New `circuit_to_iqm()` is a **thin IR-to-wire translator** — only `PRX(θ, φ)`, `CZ`, and `Measure` instructions go through; everything else returns `HalError::InvalidCircuit` with a clear "compile via `arvak.compile(target=\"iqm_<target>\")` first" message
- `validate()` enforces the IQM-native gate set advertised by `Capabilities::iqm()` (`{prx, cz}`)
- `status()` is a single `GET /jobs/{id}` (no more separate `/status`)
- `result()` confirms terminal status, then fetches `measurement_counts` and converts to HAL `Counts` with qubit-0-rightmost bit order
- `availability()` now queries `GET /quantum-computers/{qc}/health` (5-min TTL cached)

## HAL contract layering

This adapter is now strictly a thin wire translator — it advertises its native gate set, validates against it, and refuses to compile. Decomposing arbitrary user gates into PRX/CZ is `arvak-compile`'s responsibility, same pattern as IBM Heron, AQT, Quantinuum, and Quandela adapters. Every other variant I considered for this PR would have put a transpiler inside the adapter, breaking that layering.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p arvak-adapter-iqm --all-targets` with full pedantic config — clean
- [x] `cargo test -p arvak-adapter-iqm --lib` — **31/31 pass** (new tests cover wire format, status enum round-trip, bit order, native-only validation, helpful reject messages)
- [x] `cargo check --workspace --exclude arvak-python` — clean
- [x] `maturin develop --release` — Python wheel builds
- [x] **Live verification against IQM Garnet QPU** — submitted `PRX(π/2, 0)` on QB1 + measure, 1 shot, via `arvak.run()` through the Python bindings. Round-trip completed in 57s wall; counts came back `{'0': 1}`, consistent with a 50/50 superposition outcome.
- [x] Phase 6.6 smoke — 11/11 pass, no regression in non-IQM backends
- [ ] CI: this PR's run

## Out of scope (separate follow-up PRs)

- **`arvak-compile` IQM-native lowering target.** Users who want to submit raw `H`/`CX`/`Rx` circuits to IQM must pre-transpile (qiskit-iqm) or wait for the compile target.
- **Sirius `move` instruction emission** for cross-resonator entangling gates. Garnet/Emerald/Crystal (planar grids) work without this; Sirius works only for circuits with no inter-data-qubit CZ.
- **Live `QcLimits` query** in `from_config_impl` to replace the static qubit-count map. Static values (Sirius=16, Emerald/Crystal=54, default Garnet=20) are correct as of 2026-06-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)