### PR TITLE
chore(release): v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to Arvak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-06-25
+
+Closes the additive part of RFC-0001 (Native Backend Unification) and
+brings the IQM adapter onto the current Resonance v1 API. Live shot
+verification on real hardware: IBM Marrakesh (156q Heron), IQM Garnet
+(20q Resonance), Quandela `sim:ascella`. Five PRs merged.
+
+### Added
+
+- **AWS Braket, NVIDIA CUDA-Q, MQT DDSIM in the Python registry** (#30).
+  13 new backend names: `braket_sv1/tn1/dm1/rigetti_ankaa/ionq_aria_{1,2}/
+  ionq_forte_1/iqm_garnet`, `cudaq_mqpu/custatevec/tensornet/density_matrix`,
+  `ddsim`. Each routes through `make_backend()` with feature gating
+  (`adapter-braket`, `adapter-cudaq`, `adapter-ddsim`), env-var
+  pre-validation, and the same constructor pattern as Phase 6/6.5.
+  After this PR every adapter in tree except QDMI is in the native
+  registry.
+
+### Changed
+
+- **IQM Resonance v1 API migration** (#33). The
+  `cocos.resonance.meetiqm.com/api/v1` endpoint was retired by IQM.
+  Full rewrite of `arvak-adapter-iqm` against `resonance.iqm.tech/api/v1`:
+  - New URL structure (`POST /jobs/{qc}/{job_type}`; `GET /jobs/{id}`
+    replaces separate status/result endpoints; counts live under
+    `/artifacts/measurement_counts`).
+  - New JSON wire format (IR-style `{circuits: [{name, instructions:
+    [{name, locus, args, implementation}]}], shots}` with QB1/QB2/...
+    locus labels).
+  - New status enum `{waiting, processing, completed, failed,
+    cancelled}`, mapped to HAL `JobStatus`.
+  - HAL-thin layering: adapter advertises native gate set `{prx, cz}`,
+    `validate()` rejects non-native circuits with an actionable
+    `arvak.compile()` message — transpilation lives in arvak-compile,
+    not in the adapter (matches the IBM Heron / AQT / Quantinuum /
+    Quandela pattern).
+  - Always sends `User-Agent: arvak-adapter-iqm/1.0` (the new endpoint
+    is fronted by Cloudflare and 1010-blocks bare HTTP clients).
+  - Live-verified end-to-end: `PRX(π/2, 0)` + measure on Garnet,
+    real-shot round trip.
+
+- **IBM backend list pruned of retired devices** (#32).
+  Six 127q Eagle systems IBM retired during 2025 — Kyoto, Osaka,
+  Brisbane, Sherbrooke, Nazca, Torino — removed from
+  `arvak.list_backends()`. Remaining IBM names: `fez`, `marrakesh`
+  (US-East Heron r3), `brussels`, `strasbourg`, `aachen` (EU
+  Frankfurt, require `IBM_SERVICE_CRN_EU`). `make_backend()`'s
+  `ibm_*` prefix branch still accepts any name and surfaces the IBM
+  Cloud error for unrecognised ones — `list_backends()` is the
+  *advertised* surface, not the gate.
+
+### Fixed
+
+- **Quandela `quandela_altair` registry mapping** (#31).
+  `make_backend()` mapped it to the literal string `"quandela_altair"`;
+  the real Perceval Cloud platform name is `qpu:altair`. Result: 404
+  on every construction. Now routes correctly. (Free-tier tokens still
+  get 403 because Altair access is gated upstream — that's a vendor
+  auth concern.)
+
+- **Quandela job-status parser** (#31).
+  Quandela's server returns `"completed"` for success, not
+  `"success"`. The bridge compared against `"SUCCESS"` (after
+  `.upper()`) and every successful job got mapped to the bridge's
+  `"unknown"` sentinel, surfaced to the caller as `Failed("unknown
+  status: unknown")` — jobs that **completed successfully upstream
+  were being reported as failed**. Fix: route the raw status through
+  Perceval's own `RunningStatus.from_server_response()` (which knows
+  the `"completed"` special case) and map all eight enum values
+  explicitly. `SUSPENDED` and `CANCEL_REQUESTED` now map to
+  `"running"` (transient, non-terminal).
+
+- **Quandela shot accounting on photonic backends** (#34).
+  The bridge was calling
+  `Sampler(rp, max_shots_per_call=shots).sample_count.execute_async(shots)`
+  with the same value in both places. In Perceval those mean different
+  things: `max_shots_per_call` is the total laser-pulse budget; the
+  argument to `execute_async` is the target post-selected sample
+  count. With heralded gates (postprocessed CNOT: ~1/9 success) and
+  dual-rail decoding, the actual yield is ~10–15% — at `shots=500`
+  the user got 2 samples back. Fix: `max_shots = max(shots * 100,
+  10_000)`, multiplier overridable via `PCVL_SHOT_BUDGET_MULTIPLIER`.
+  Before: Bell-state fraction 50% on `sim:ascella`. After: 92.8%.
+
+- **Quandela `_decode_results` dropping garbage dual-rail events** (#34).
+  Events where a qubit's dual-rail couldn't be cleanly decoded (photon
+  collision or partial detection) used to append `"?"` and accumulate
+  into the count dict as separate buckets (e.g. `"1?"`). Those leaked
+  into the Bell-fraction calculation. Now dropped entirely — a
+  partially-decoded photonic event is *undetected*, not a distinct
+  outcome.
+
 ## [1.9.2] - 2026-03-05
 
 ### Added
@@ -779,6 +871,7 @@ If upgrading from development versions:
 
 ---
 
+[1.10.0]: https://github.com/hiq-lab/arvak/releases/tag/v1.10.0
 [1.9.2]: https://github.com/hiq-lab/arvak/releases/tag/v1.9.2
 [1.9.1]: https://github.com/hiq-lab/arvak/releases/tag/v1.9.1
 [1.9.0]: https://github.com/hiq-lab/arvak/releases/tag/v1.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-aqt"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-braket"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-cudaq"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-ddsim"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-ibm"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-ionq"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-iqm"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-qdmi"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-quandela"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-quantinuum"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-scaleway"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-adapter-sim"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-auto"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "petgraph",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-bench"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-compile",
  "arvak-ir",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-cli"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-aqt",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-compile"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "num-complex",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-dashboard"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-sim",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-demos"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-compile",
  "arvak-hal",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-eval"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-compile",
  "arvak-hal",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-grpc"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arvak-adapter-aqt",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-hal"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "async-trait",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-ir"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "criterion",
  "num-complex",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-proj"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "faer",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-python"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-adapter-aqt",
  "arvak-adapter-braket",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-qasm3"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "logos",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-qdmi"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "libloading",
  "tempfile",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-qdmi-device"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-grpc",
  "arvak-qdmi",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-sched"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-hal",
  "arvak-ir",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-sim"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "rand 0.8.6",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "arvak-types"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "arvak-ir",
  "proptest",
@@ -3462,7 +3462,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumi-hybrid"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.9.5"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arvak: Rust-Native Quantum Compilation Stack
 
-[![Version](https://img.shields.io/badge/version-1.9.5-blue.svg)](https://github.com/hiq-lab/arvak/releases/tag/v1.9.5)
+[![Version](https://img.shields.io/badge/version-1.10.0-blue.svg)](https://github.com/hiq-lab/arvak/releases/tag/v1.10.0)
 [![PyPI](https://img.shields.io/pypi/v/arvak.svg)](https://pypi.org/project/arvak/)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)

--- a/crates/arvak-python/pyproject.toml
+++ b/crates/arvak-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "arvak"
-version = "1.9.4"
+version = "1.10.0"
 description = "Arvak - Rust-native quantum compilation and orchestration platform for HPC with CUDA-Q, neutral-atom, and dynamic plugin support. Developed by The HAL Contract."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/arvak-qdmi-device/src/lib.rs
+++ b/crates/arvak-qdmi-device/src/lib.rs
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn ARVAK_QDMI_device_session_query_device_property(
                     write_query_result(data, size, value, size_ret)
                 }
                 ffi::QDMI_DEVICE_PROPERTY_VERSION => {
-                    let data = b"1.9.4\0";
+                    let data = b"1.10.0\0";
                     write_query_result(data, size, value, size_ret)
                 }
                 ffi::QDMI_DEVICE_PROPERTY_STATUS => {


### PR DESCRIPTION
## Summary

Workspace version 1.9.5 → **1.10.0**. Minor bump, not major: all work in this train is additive (Phase 6.6 native registry for Braket / CUDA-Q / DDSIM) or fixes broken endpoints (IQM Resonance v1 migration, Quandela status parser, Quandela shot accounting, IBM retired-device prune). The HAL `Backend` trait, `Capabilities`, and the Python `arvak.run` surface are all unchanged.

Phase 7 (delete the legacy `Arvak*Backend` classes that already emit `DeprecationWarning`) is parked for **2.0.0**.

## What's in 1.10.0

Five PRs merged into main this train:

| PR | Title |
|---|---|
| #30 | Phase 6.6 — wire native Braket + CUDA-Q + DDSIM adapters |
| #31 | fix(quandela): Altair routing + Perceval enum status mapping |
| #32 | fix(python): prune retired IBM 127q Eagles from list_backends() |
| #33 | feat(iqm): migrate IQM adapter to Resonance v1 API (HAL-thin) |
| #34 | fix(quandela): shot accounting + drop garbage dual-rail decodes |

Live shot verification covered:
- **IBM Marrakesh** (156q Heron QPU) — Bell state, real round-trip
- **IQM Garnet** (20q Resonance) — `PRX(π/2, 0)`, real shot via new `/api/v1`
- **Quandela sim:ascella** — 2000 shots, Bell fraction **92.8%**

## What changed in this PR

- `Cargo.toml` — `workspace.package.version` 1.9.5 → 1.10.0
- `crates/arvak-python/pyproject.toml` — `project.version` 1.9.4 → 1.10.0 (was lagging)
- `crates/arvak-qdmi-device/src/lib.rs` — `QDMI_DEVICE_PROPERTY_VERSION` 1.9.4 → 1.10.0
- `README.md` — version badge
- `Cargo.lock` — auto-updated by `cargo check`
- `CHANGELOG.md` — full 1.10.0 entry

## Test plan

- [x] `cargo check --workspace --exclude arvak-python` — clean
- [x] `cargo test --lib -p arvak-adapter-iqm -p arvak-adapter-quandela` — pass
- [ ] CI: this PR's run
- [ ] After merge: tag `v1.10.0` on main, push tag, GitHub Release with CHANGELOG excerpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)