### PR TITLE
fix(ci,docker): drop references to crates removed in the cleanup scrub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run tests
-        run: cargo test --workspace --exclude arvak-python --exclude arvak-proj
+        run: cargo test --workspace --exclude arvak-python
 
   fmt:
     name: Formatting

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,11 +206,11 @@ jobs:
 
       - name: Run tests (debug)
         if: matrix.profile == 'debug'
-        run: cargo test --workspace --exclude arvak-python --exclude arvak-proj
+        run: cargo test --workspace --exclude arvak-python
 
       - name: Run tests (release)
         if: matrix.profile == 'release'
-        run: cargo test --workspace --exclude arvak-python --exclude arvak-proj --release
+        run: cargo test --workspace --exclude arvak-python --release
 
       # Adapter feature-flag builds (ubuntu release only — folded from adapter-compat)
       - name: Build CLI with all backends

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ COPY adapters/arvak-adapter-cudaq/Cargo.toml adapters/arvak-adapter-cudaq/Cargo.
 COPY crates/arvak-eval/Cargo.toml crates/arvak-eval/Cargo.toml
 COPY crates/arvak-bench/Cargo.toml crates/arvak-bench/Cargo.toml
 COPY demos/Cargo.toml demos/Cargo.toml
-COPY demos/lumi-hybrid/Cargo.toml demos/lumi-hybrid/Cargo.toml
 
 # Create stub source files matching each crate's expected targets
 RUN mkdir -p .hal-contract/rust/src && echo "" > .hal-contract/rust/src/lib.rs \
@@ -96,9 +95,6 @@ RUN mkdir -p .hal-contract/rust/src && echo "" > .hal-contract/rust/src/lib.rs \
         && echo "fn main() {}" > demos/bin/demo_speed_vqe.rs \
         && echo "fn main() {}" > demos/bin/demo_speed_qml.rs \
         && echo "fn main() {}" > demos/bin/demo_speed_qaoa.rs \
-    && mkdir -p demos/lumi-hybrid/src \
-        && echo "fn main() {}" > demos/lumi-hybrid/src/main.rs \
-        && echo "fn main() {}" > demos/lumi-hybrid/src/quantum_worker.rs \
     && mkdir -p demos/data \
         && echo "{}" > demos/data/vqe_result.json
 
@@ -126,7 +122,7 @@ RUN find crates/ adapters/ demos/ -name "*.rs" -exec touch {} +
 RUN cargo build --release -p arvak-dashboard --features "${DASHBOARD_FEATURES}"
 RUN cargo build --release -p arvak-cli
 RUN cargo build --release -p arvak-grpc --features "simulator,sqlite,ibm"
-RUN cargo build --release -p arvak-demos -p lumi-hybrid
+RUN cargo build --release -p arvak-demos
 
 # ============================================================
 # Stage 2: Runtime (minimal)


### PR DESCRIPTION
## Summary

The repo-scrub commit (2026-06-26) removed \`demos/lumi-hybrid/\` and \`crates/arvak-proj/\`, but three build-infra files still reference them:

- \`Dockerfile\` COPYs \`demos/lumi-hybrid/Cargo.toml\` and builds \`lumi-hybrid\` → **Docker Build failed in nightly on both 2026-06-27 and 2026-06-28** with \"\`/demos/lumi-hybrid/Cargo.toml\`: not found\"
- \`.github/workflows/ci.yml\` passes \`--exclude arvak-proj\` to \`cargo test\` — Cargo warns but doesn't hard-error, so CI stayed green; housekeeping only
- \`.github/workflows/nightly.yml\` same pattern, twice (debug + release)

## Changes

| File | Edit |
|---|---|
| \`Dockerfile\` | Drop \`COPY demos/lumi-hybrid/Cargo.toml\`, drop stub \`src/\` mkdir, drop \`-p lumi-hybrid\` from final cargo build |
| \`.github/workflows/ci.yml\` | Drop \`--exclude arvak-proj\` from the test step |
| \`.github/workflows/nightly.yml\` | Drop \`--exclude arvak-proj\` from debug + release test steps |

3 files, +4 / −8.

## Test plan

- [x] No remaining matches for \`lumi-hybrid|arvak-proj\` in \`Dockerfile\`, \`.github/\`, or \`scripts/\` (verified with grep)
- [ ] CI: this PR's run
- [ ] Nightly: post-merge, the Docker Build job should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)