### PR TITLE
fix(docker): drop runtime COPY of lumi-hybrid binaries (nightly Docker Build fix-up)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,8 +151,6 @@ COPY --from=builder /build/target/release/demo-qi-nutshell /usr/local/bin/demo-q
 COPY --from=builder /build/target/release/demo-speed-vqe /usr/local/bin/demo-speed-vqe
 COPY --from=builder /build/target/release/demo-speed-qml /usr/local/bin/demo-speed-qml
 COPY --from=builder /build/target/release/demo-speed-qaoa /usr/local/bin/demo-speed-qaoa
-COPY --from=builder /build/target/release/lumi_vqe /usr/local/bin/lumi_vqe
-COPY --from=builder /build/target/release/quantum_worker /usr/local/bin/quantum_worker
 
 # Copy example QASM files
 COPY examples/*.qasm /home/arvak/examples/


### PR DESCRIPTION
PR #38 cleaned the **builder** stage of the Dockerfile but missed two lines in the **runtime** stage that still tried to COPY binaries from the build cache:

\`\`\`dockerfile
COPY --from=builder /build/target/release/lumi_vqe /usr/local/bin/lumi_vqe
COPY --from=builder /build/target/release/quantum_worker /usr/local/bin/quantum_worker
\`\`\`

The manual nightly after #38 merged failed with:

\`\`\`
ERROR: failed to calculate checksum of ref ...:
"/build/target/release/quantum_worker": not found
ERROR: failed to calculate checksum of ref ...:
"/build/target/release/lumi_vqe": not found
\`\`\`

Drop both lines. 1 file, −2.

## Test plan

- [x] No remaining matches for \`lumi|lumi-hybrid|arvak-proj|alsvid|qoblib\` in \`Dockerfile\`, \`.github/workflows/\`, \`scripts/\` (verified with grep; only false positives are LUMI-as-HPC-site comments in `audit.sh`).
- [ ] CI: this PR's run
- [ ] Manual nightly trigger after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)