### PR TITLE
feat(hal)!: validate(circuit, shots) per HAL Contract v2 §3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ demos/data/*/
 
 # HAL contract spec (checked out from external repo at CI time)
 .hal-contract
+*.dSYM/

--- a/adapters/arvak-adapter-aqt/src/backend.rs
+++ b/adapters/arvak-adapter-aqt/src/backend.rs
@@ -371,7 +371,7 @@ impl Backend for AqtBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -382,6 +382,17 @@ impl Backend for AqtBackend {
                 circuit.num_qubits(),
                 self.resource,
                 caps.num_qubits
+            ));
+        }
+
+        // Check shot count.
+        if shots == 0 {
+            reasons.push("Shot count must be at least 1".into());
+        }
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {shots} shots but AQT maximum is {}",
+                caps.max_shots
             ));
         }
 
@@ -453,17 +464,8 @@ impl Backend for AqtBackend {
             shots
         );
 
-        let caps = self.capabilities();
-
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but AQT {} supports at most {}",
-                circuit.num_qubits(),
-                self.resource,
-                caps.num_qubits
-            )));
-        }
-
+        // Precise fast-fail on shot bounds (InvalidShots is more specific
+        // than InvalidCircuit and callers may rely on it).
         if shots > AQT_MAX_SHOTS {
             return Err(HalError::InvalidShots(format!(
                 "Requested {shots} shots but AQT maximum is {AQT_MAX_SHOTS}"
@@ -476,18 +478,15 @@ impl Backend for AqtBackend {
             ));
         }
 
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        // RequiresTranspilation does not block submission.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
+        }
+
         let n_qubits = u32::try_from(circuit.num_qubits()).unwrap_or(AQT_MAX_QUBITS);
 
         let ops = Self::serialize_circuit(circuit).map_err(|e| HalError::Backend(e.to_string()))?;
-
-        if ops.len() > AQT_MAX_OPS + 1 {
-            // +1 for the terminal MEASURE
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} operations but AQT allows at most {}",
-                ops.len() - 1,
-                AQT_MAX_OPS
-            )));
-        }
 
         let circuit_payload = CircuitPayload {
             repetitions: shots,
@@ -754,6 +753,34 @@ mod tests {
 
         let result = AqtBackend::gate_to_aqt_op(&gate, &qubits);
         assert!(matches!(result, Err(AqtError::UnsupportedGate(_))));
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_shots_over_max() {
+        let backend = AqtBackend::with_token(DEFAULT_WORKSPACE, DEFAULT_RESOURCE, "test-token")
+            .expect("constructs");
+
+        let circuit = Circuit::with_size("shots-test", 1, 1);
+        let vr = backend.validate(&circuit, AQT_MAX_SHOTS + 1).await.unwrap();
+        match vr {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "expected a shots reason, got {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_accepts_shots_within_max() {
+        let backend = AqtBackend::with_token(DEFAULT_WORKSPACE, DEFAULT_RESOURCE, "test-token")
+            .expect("constructs");
+
+        let circuit = Circuit::with_size("shots-ok", 1, 1);
+        let vr = backend.validate(&circuit, 100).await.unwrap();
+        assert!(matches!(vr, ValidationResult::Valid), "got {vr:?}");
     }
 
     #[test]

--- a/adapters/arvak-adapter-braket/src/backend.rs
+++ b/adapters/arvak-adapter-braket/src/backend.rs
@@ -252,7 +252,7 @@ impl Backend for BraketBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -263,6 +263,24 @@ impl Backend for BraketBackend {
                 circuit.num_qubits(),
                 caps.num_qubits
             ));
+        }
+
+        // Check shot count
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but device allows at most {}",
+                shots, caps.max_shots
+            ));
+        }
+
+        // Check operation count
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "Circuit has {num_ops} operations but device allows at most {max_ops}"
+                ));
+            }
         }
 
         // Check gate set support
@@ -297,13 +315,9 @@ impl Backend for BraketBackend {
             ));
         }
 
-        // Validate qubit count
-        if circuit.num_qubits() > self.capabilities.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit requires {} qubits but device only has {}",
-                circuit.num_qubits(),
-                self.capabilities.num_qubits
-            )));
+        // Pre-submission validation: catch constraint violations before dispatch.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
         // Convert circuit to QASM3
@@ -516,6 +530,30 @@ mod tests {
         };
         let counts = BraketBackend::parse_result(&result, 2, 1);
         assert_eq!(counts.get("01"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_excess_shots() {
+        let client = BraketClient::new("us-east-1", "test-bucket", "test-prefix")
+            .await
+            .unwrap();
+        let backend = BraketBackend {
+            client: Arc::new(client),
+            device_arn: "arn:aws:braket:::device/quantum-simulator/amazon/sv1".to_string(),
+            capabilities: Capabilities::braket_simulator("SV1", 34),
+            jobs: Arc::new(Mutex::new(FxHashMap::default())),
+            device_info: Arc::new(RwLock::new(None)),
+        };
+        let circuit = Circuit::with_size("test", 2, 2);
+
+        let max_shots = backend.capabilities().max_shots;
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(reasons.iter().any(|r| r.contains("shots")));
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-cudaq/src/backend.rs
+++ b/adapters/arvak-adapter-cudaq/src/backend.rs
@@ -239,7 +239,7 @@ impl Backend for CudaqBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -249,6 +249,13 @@ impl Backend for CudaqBackend {
                 circuit.num_qubits(),
                 self.target,
                 caps.num_qubits
+            ));
+        }
+
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but {} supports max {}",
+                shots, self.target, caps.max_shots
             ));
         }
 
@@ -281,20 +288,19 @@ impl Backend for CudaqBackend {
         );
 
         let caps = self.capabilities();
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but {} supports max {}",
-                circuit.num_qubits(),
-                self.target,
-                caps.num_qubits
-            )));
-        }
-
         if shots > caps.max_shots {
             return Err(HalError::InvalidShots(format!(
                 "Requested {} shots but maximum is {}",
                 shots, caps.max_shots
             )));
+        }
+
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        match self.validate(circuit, shots).await? {
+            ValidationResult::Invalid { reasons } => {
+                return Err(HalError::InvalidCircuit(reasons.join("; ")));
+            }
+            ValidationResult::Valid | ValidationResult::RequiresTranspilation { .. } => {}
         }
 
         let qasm = self
@@ -545,6 +551,21 @@ mod tests {
 
         assert_eq!(caps.name, "tensornet");
         assert_eq!(caps.num_qubits, 100);
+    }
+
+    #[tokio::test]
+    async fn test_validate_too_many_shots() {
+        let config = BackendConfig::new("cudaq")
+            .with_endpoint(DEFAULT_ENDPOINT)
+            .with_token("test-token");
+
+        let backend = CudaqBackend::from_config_impl(config).unwrap();
+        let max_shots = backend.capabilities().max_shots;
+
+        let circuit = Circuit::with_size("test", 2, 2);
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+
+        assert!(matches!(result, ValidationResult::Invalid { .. }));
     }
 
     #[test]

--- a/adapters/arvak-adapter-ddsim/src/backend.rs
+++ b/adapters/arvak-adapter-ddsim/src/backend.rs
@@ -208,7 +208,7 @@ impl Backend for DdsimBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let mut reasons = Vec::new();
 
         if circuit.num_qubits() > self.max_qubits as usize {
@@ -216,6 +216,13 @@ impl Backend for DdsimBackend {
                 "Circuit has {} qubits but DDSIM adapter is configured for max {}",
                 circuit.num_qubits(),
                 self.max_qubits
+            ));
+        }
+
+        if shots > self.capabilities.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but DDSIM adapter supports max {}",
+                shots, self.capabilities.max_shots
             ));
         }
 
@@ -245,13 +252,12 @@ impl Backend for DdsimBackend {
             ));
         }
 
-        // Validate qubit count
-        if circuit.num_qubits() > self.max_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but DDSIM adapter supports max {}",
-                circuit.num_qubits(),
-                self.max_qubits
-            )));
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        match self.validate(circuit, shots).await? {
+            ValidationResult::Invalid { reasons } => {
+                return Err(HalError::InvalidCircuit(reasons.join("; ")));
+            }
+            ValidationResult::Valid | ValidationResult::RequiresTranspilation { .. } => {}
         }
 
         // Serialize to QASM2
@@ -427,7 +433,16 @@ mod tests {
     async fn test_ddsim_validate_too_many_qubits() {
         let backend = DdsimBackend::with_max_qubits(5);
         let circuit = Circuit::with_size("test", 10, 0);
-        let result = backend.validate(&circuit).await.unwrap();
+        let result = backend.validate(&circuit, 100).await.unwrap();
+        assert!(matches!(result, ValidationResult::Invalid { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_ddsim_validate_too_many_shots() {
+        let backend = DdsimBackend::new();
+        let max_shots = backend.capabilities().max_shots;
+        let circuit = Circuit::bell().unwrap();
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
         assert!(matches!(result, ValidationResult::Invalid { .. }));
     }
 
@@ -436,7 +451,7 @@ mod tests {
         let backend = DdsimBackend::with_max_qubits(5);
         let circuit = Circuit::with_size("test", 10, 0);
         let result = backend.submit(&circuit, 100, None).await;
-        assert!(matches!(result, Err(HalError::CircuitTooLarge(_))));
+        assert!(matches!(result, Err(HalError::InvalidCircuit(_))));
     }
 
     /// Integration test: runs only when DDSIM is installed.

--- a/adapters/arvak-adapter-ibm/src/backend.rs
+++ b/adapters/arvak-adapter-ibm/src/backend.rs
@@ -452,7 +452,7 @@ impl Backend for IbmBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -462,6 +462,22 @@ impl Backend for IbmBackend {
                 circuit.num_qubits(),
                 caps.num_qubits
             ));
+        }
+
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but backend allows at most {}",
+                shots, caps.max_shots
+            ));
+        }
+
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "Circuit has {num_ops} operations but backend allows at most {max_ops}"
+                ));
+            }
         }
 
         if !reasons.is_empty() {
@@ -515,27 +531,18 @@ impl Backend for IbmBackend {
             ));
         }
 
-        // Pre-submission validation (DEBT-01): catch unsupported gates and
-        // qubit-count violations before burning queue time or quantum credits.
-        if let ValidationResult::Invalid { reasons } = self.validate(circuit).await? {
+        // Pre-submission validation (DEBT-01): catch unsupported gates, qubit-count
+        // and shot-count violations before burning queue time or quantum credits.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
             return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
-        // Check qubit count
+        // Check if backend is operational
         let info = self
             .get_backend_info()
             .await
             .map_err(|e| HalError::Backend(e.to_string()))?;
 
-        if circuit.num_qubits() > info.num_qubits {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit requires {} qubits but backend only has {}",
-                circuit.num_qubits(),
-                info.num_qubits
-            )));
-        }
-
-        // Check if backend is operational
         if !info.status.operational {
             return Err(HalError::BackendUnavailable(
                 info.status
@@ -797,6 +804,22 @@ mod tests {
         // Single qubit: max 1 → 1 bit
         let samples = vec!["0x0".into(), "0x1".into()];
         assert_eq!(infer_bit_width(&samples), 1);
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_excess_shots() {
+        let config = BackendConfig::new("ibm").with_token("test-token");
+        let backend = IbmBackend::with_config(config).unwrap();
+        let circuit = Circuit::with_size("test", 2, 2);
+
+        let max_shots = backend.capabilities().max_shots;
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(reasons.iter().any(|r| r.contains("shots")));
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-ionq/src/backend.rs
+++ b/adapters/arvak-adapter-ionq/src/backend.rs
@@ -494,7 +494,7 @@ impl Backend for IonQBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -506,6 +506,27 @@ impl Backend for IonQBackend {
                 self.backend_name,
                 caps.num_qubits
             ));
+        }
+
+        // Check shot count.
+        if shots == 0 {
+            reasons.push("Shot count must be at least 1".to_string());
+        } else if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but IonQ {} allows at most {}",
+                shots, self.backend_name, caps.max_shots
+            ));
+        }
+
+        // Check operation count.
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "Circuit has {num_ops} operations but IonQ {} allows at most {max_ops}",
+                    self.backend_name
+                ));
+            }
         }
 
         // Check gate set.
@@ -565,23 +586,18 @@ impl Backend for IonQBackend {
             shots
         );
 
-        let caps = self.capabilities();
-
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but IonQ {} supports at most {}",
-                circuit.num_qubits(),
-                self.backend_name,
-                caps.num_qubits
-            )));
-        }
-
         if shots == 0 {
             return Err(HalError::InvalidShots(
                 "Shot count must be at least 1".into(),
             ));
         }
 
+        // Pre-submission validation: catch constraint violations before dispatch.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
+        }
+
+        let caps = self.capabilities();
         let n_qubits = u32::try_from(circuit.num_qubits()).unwrap_or(caps.num_qubits);
 
         let gates =
@@ -895,6 +911,21 @@ mod tests {
         let qubits = vec![QubitId(0)];
         let result = IonQBackend::gate_to_ionq(&gate, &qubits);
         assert!(matches!(result, Err(IonQError::UnsupportedGate(_))));
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_excess_shots() {
+        let backend = IonQBackend::with_api_key(SIMULATOR, "test-key").unwrap();
+        let circuit = Circuit::with_size("test", 2, 2);
+
+        let max_shots = backend.capabilities().max_shots;
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(reasons.iter().any(|r| r.contains("shots")));
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-iqm/src/backend.rs
+++ b/adapters/arvak-adapter-iqm/src/backend.rs
@@ -433,7 +433,7 @@ impl Backend for IqmBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -443,6 +443,13 @@ impl Backend for IqmBackend {
                 circuit.num_qubits(),
                 self.target,
                 caps.num_qubits
+            ));
+        }
+
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but maximum is {}",
+                shots, caps.max_shots
             ));
         }
 
@@ -493,20 +500,20 @@ impl Backend for IqmBackend {
             shots
         );
 
+        // Precise fast-fail on shot bounds (InvalidShots is more specific
+        // than InvalidCircuit and callers may rely on it).
         let caps = self.capabilities();
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but {} only supports {}",
-                circuit.num_qubits(),
-                self.target,
-                caps.num_qubits
-            )));
-        }
         if shots > caps.max_shots {
             return Err(HalError::InvalidShots(format!(
                 "Requested {} shots but maximum is {}",
                 shots, caps.max_shots
             )));
+        }
+
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        // RequiresTranspilation does not block submission.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
         let iqm_circuit = self.circuit_to_iqm(circuit)?;
@@ -711,7 +718,7 @@ mod tests {
         // Build a circuit with H (not native) — must be rejected.
         let mut c = Circuit::with_size("h-test", 1, 1);
         c.h(QubitId(0)).unwrap();
-        let vr = backend.validate(&c).await.unwrap();
+        let vr = backend.validate(&c, 100).await.unwrap();
         match vr {
             ValidationResult::Invalid { reasons } => {
                 assert!(
@@ -742,8 +749,27 @@ mod tests {
         c.measure(QubitId(0), arvak_ir::ClbitId(0)).unwrap();
         c.measure(QubitId(1), arvak_ir::ClbitId(1)).unwrap();
 
-        let vr = backend.validate(&c).await.unwrap();
+        let vr = backend.validate(&c, 100).await.unwrap();
         assert!(matches!(vr, ValidationResult::Valid), "got {vr:?}");
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_shots_over_max() {
+        let backend =
+            IqmBackend::with_credentials("https://example/api/v1", "test-token", "garnet").unwrap();
+
+        let c = Circuit::with_size("shots-test", 1, 1);
+        let over = backend.capabilities().max_shots + 1;
+        let vr = backend.validate(&c, over).await.unwrap();
+        match vr {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "expected a shots reason, got {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-qdmi/src/backend.rs
+++ b/adapters/arvak-adapter-qdmi/src/backend.rs
@@ -878,7 +878,7 @@ impl Backend for QdmiBackend {
         Ok(BackendAvailability::unavailable("failed to initialize"))
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -888,6 +888,24 @@ impl Backend for QdmiBackend {
                 circuit.num_qubits(),
                 caps.num_qubits
             ));
+        }
+
+        // Shot count (HAL Contract v2 §3.3).
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but device supports at most {}",
+                shots, caps.max_shots
+            ));
+        }
+
+        // Total operation count (when the backend imposes a limit).
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "Circuit has {num_ops} operations but maximum is {max_ops}"
+                ));
+            }
         }
 
         // Check gate set support
@@ -920,6 +938,11 @@ impl Backend for QdmiBackend {
             return Err(HalError::Unsupported(
                 "QDMI backend does not support runtime parameter binding".into(),
             ));
+        }
+
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
         debug!("Submitting circuit with {} shots via QDMI", shots);
@@ -1338,6 +1361,26 @@ mod tests {
 
         let status = backend.status(&job_id).await.unwrap();
         assert!(matches!(status, JobStatus::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn test_qdmi_validate_rejects_excessive_shots() {
+        let backend = QdmiBackend::new();
+
+        let mut circuit = Circuit::with_size("test", 1, 1);
+        circuit.h(arvak_ir::QubitId(0)).unwrap();
+
+        let max_shots = backend.capabilities().max_shots;
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "reasons should mention shots: {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid for excessive shots, got {other:?}"),
+        }
     }
 
     /// Gate set is now built from `MockDevice::operations`, not hardcoded to universal.

--- a/adapters/arvak-adapter-quandela/src/backend.rs
+++ b/adapters/arvak-adapter-quandela/src/backend.rs
@@ -317,7 +317,7 @@ impl Backend for QuandelaBackend {
     }
 
     #[instrument(skip(self, circuit))]
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -329,6 +329,24 @@ impl Backend for QuandelaBackend {
                 self.platform,
                 caps.num_qubits,
             ));
+        }
+
+        // Shot count (HAL Contract v2 §3.3).
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "requested {} shots; {} supports at most {}",
+                shots, self.platform, caps.max_shots,
+            ));
+        }
+
+        // Total operation count (when the backend imposes a limit).
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "circuit has {num_ops} operations; maximum is {max_ops}"
+                ));
+            }
         }
 
         // Gate set.
@@ -361,6 +379,11 @@ impl Backend for QuandelaBackend {
             return Err(HalError::Unsupported(
                 "Quandela backend does not support runtime parameter binding".into(),
             ));
+        }
+
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
         let circuit_json =
@@ -542,7 +565,7 @@ mod tests {
     async fn test_validate_bell_valid() {
         let b = QuandelaBackend::for_platform("sim:ascella").unwrap();
         let circuit = bell_circuit();
-        let result = b.validate(&circuit).await.unwrap();
+        let result = b.validate(&circuit, 100).await.unwrap();
         assert!(
             matches!(result, ValidationResult::Valid),
             "expected Valid, got {result:?}"
@@ -553,11 +576,28 @@ mod tests {
     async fn test_validate_too_many_qubits() {
         let b = QuandelaBackend::for_platform("sim:ascella").unwrap();
         let circuit = Circuit::with_size("big", 7, 0);
-        let result = b.validate(&circuit).await.unwrap();
+        let result = b.validate(&circuit, 100).await.unwrap();
         assert!(
             matches!(result, ValidationResult::Invalid { .. }),
             "expected Invalid for 7 qubits, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_validate_excessive_shots() {
+        let b = QuandelaBackend::for_platform("sim:ascella").unwrap();
+        let circuit = bell_circuit();
+        let max_shots = b.capabilities().max_shots;
+        let result = b.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "reasons should mention shots: {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid for excessive shots, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-quandela/tests/test_quandela_sim.rs
+++ b/adapters/arvak-adapter-quandela/tests/test_quandela_sim.rs
@@ -67,7 +67,10 @@ async fn test_bell_state_sim_ascella() {
     let shots = 2_000u32;
 
     // Validate first.
-    let vr = backend.validate(&circuit).await.expect("validate failed");
+    let vr = backend
+        .validate(&circuit, shots)
+        .await
+        .expect("validate failed");
     assert!(
         matches!(vr, arvak_hal::ValidationResult::Valid),
         "Bell circuit should be Valid, got {vr:?}"

--- a/adapters/arvak-adapter-quantinuum/src/backend.rs
+++ b/adapters/arvak-adapter-quantinuum/src/backend.rs
@@ -248,7 +248,7 @@ impl Backend for QuantinuumBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -258,6 +258,13 @@ impl Backend for QuantinuumBackend {
                 circuit.num_qubits(),
                 self.target,
                 caps.num_qubits
+            ));
+        }
+
+        if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {shots} shots but {} allows at most {}",
+                self.target, caps.max_shots
             ));
         }
 
@@ -300,21 +307,20 @@ impl Backend for QuantinuumBackend {
             shots
         );
 
+        // Precise fast-fail on shot bounds (InvalidShots is more specific
+        // than InvalidCircuit and callers may rely on it).
         let caps = self.capabilities();
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but {} supports at most {}",
-                circuit.num_qubits(),
-                self.target,
-                caps.num_qubits
-            )));
-        }
-
         if shots > caps.max_shots {
             return Err(HalError::InvalidShots(format!(
                 "Requested {shots} shots but maximum is {}",
                 caps.max_shots
             )));
+        }
+
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        // RequiresTranspilation does not block submission.
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
+            return Err(HalError::InvalidCircuit(reasons.join("; ")));
         }
 
         let qasm2 =
@@ -500,6 +506,37 @@ mod tests {
         let results = std::collections::HashMap::new();
         let counts = QuantinuumBackend::parse_results(&results);
         assert_eq!(counts.total_shots(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_shots_over_max() {
+        let backend =
+            QuantinuumBackend::with_credentials(DEFAULT_MACHINE, "test@example.com", "password")
+                .expect("constructs");
+
+        let circuit = Circuit::with_size("shots-test", 1, 1);
+        let over = backend.capabilities().max_shots + 1;
+        let vr = backend.validate(&circuit, over).await.unwrap();
+        match vr {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "expected a shots reason, got {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_accepts_shots_within_max() {
+        let backend =
+            QuantinuumBackend::with_credentials(DEFAULT_MACHINE, "test@example.com", "password")
+                .expect("constructs");
+
+        let circuit = Circuit::with_size("shots-ok", 1, 1);
+        let vr = backend.validate(&circuit, 100).await.unwrap();
+        assert!(matches!(vr, ValidationResult::Valid), "got {vr:?}");
     }
 
     #[test]

--- a/adapters/arvak-adapter-scaleway/src/backend.rs
+++ b/adapters/arvak-adapter-scaleway/src/backend.rs
@@ -346,7 +346,7 @@ impl Backend for ScalewayBackend {
         }
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
         let caps = self.capabilities();
         let mut reasons = Vec::new();
 
@@ -357,6 +357,26 @@ impl Backend for ScalewayBackend {
                 self.platform,
                 caps.num_qubits
             ));
+        }
+
+        // Shot count (HAL Contract v2 §3.3).
+        if shots == 0 {
+            reasons.push("shots must be ≥ 1".to_string());
+        } else if shots > caps.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but maximum is {}",
+                shots, caps.max_shots
+            ));
+        }
+
+        // Total operation count (when the backend imposes a limit).
+        if let Some(max_ops) = caps.max_circuit_ops {
+            let num_ops = circuit.dag().num_ops();
+            if num_ops > max_ops as usize {
+                reasons.push(format!(
+                    "Circuit has {num_ops} operations but maximum is {max_ops}"
+                ));
+            }
         }
 
         // Check gate set support
@@ -411,28 +431,9 @@ impl Backend for ScalewayBackend {
             )));
         }
 
-        // Pre-submission circuit validation (gate set + qubit count).
-        if let ValidationResult::Invalid { reasons } = self.validate(circuit).await? {
+        // Pre-submission validation (gate set + qubit count + shots).
+        if let ValidationResult::Invalid { reasons } = self.validate(circuit, shots).await? {
             return Err(HalError::InvalidCircuit(reasons.join("; ")));
-        }
-
-        // Validate circuit size
-        let caps = self.capabilities();
-        if circuit.num_qubits() > caps.num_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but {} only supports {}",
-                circuit.num_qubits(),
-                self.platform,
-                caps.num_qubits
-            )));
-        }
-
-        // Validate shots
-        if shots > caps.max_shots {
-            return Err(HalError::InvalidShots(format!(
-                "Requested {} shots but maximum is {}",
-                shots, caps.max_shots
-            )));
         }
 
         // Convert circuit to QASM3
@@ -702,6 +703,30 @@ mod tests {
             }
         }
         assert_eq!(counts.total_shots(), 4000);
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_excessive_shots() {
+        let backend = ScalewayBackend::with_credentials(
+            "test-key",
+            "proj-123",
+            "sess-456",
+            "QPU-GARNET-20PQ",
+        )
+        .unwrap();
+        let circuit = Circuit::bell().unwrap();
+        let max_shots = backend.capabilities().max_shots;
+
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+        match result {
+            ValidationResult::Invalid { reasons } => {
+                assert!(
+                    reasons.iter().any(|r| r.contains("shots")),
+                    "reasons should mention shots: {reasons:?}"
+                );
+            }
+            other => panic!("expected Invalid for excessive shots, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/arvak-adapter-sim/src/simulator.rs
+++ b/adapters/arvak-adapter-sim/src/simulator.rs
@@ -184,17 +184,29 @@ impl Backend for SimulatorBackend {
         Ok(BackendAvailability::always_available())
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
+        let mut reasons = Vec::new();
+
         if circuit.num_qubits() > self.max_qubits as usize {
-            return Ok(ValidationResult::Invalid {
-                reasons: vec![format!(
-                    "Circuit has {} qubits but simulator only supports {}",
-                    circuit.num_qubits(),
-                    self.max_qubits
-                )],
-            });
+            reasons.push(format!(
+                "Circuit has {} qubits but simulator only supports {}",
+                circuit.num_qubits(),
+                self.max_qubits
+            ));
         }
-        Ok(ValidationResult::Valid)
+
+        if shots > self.capabilities.max_shots {
+            reasons.push(format!(
+                "Requested {} shots but simulator supports max {}",
+                shots, self.capabilities.max_shots
+            ));
+        }
+
+        if reasons.is_empty() {
+            Ok(ValidationResult::Valid)
+        } else {
+            Ok(ValidationResult::Invalid { reasons })
+        }
     }
 
     #[instrument(skip(self, circuit, parameters))]
@@ -211,13 +223,12 @@ impl Backend for SimulatorBackend {
             ));
         }
 
-        // Validate circuit size
-        if circuit.num_qubits() > self.max_qubits as usize {
-            return Err(HalError::CircuitTooLarge(format!(
-                "Circuit has {} qubits but simulator only supports {}",
-                circuit.num_qubits(),
-                self.max_qubits
-            )));
+        // HAL Contract v2 §3.3 rule 4: validate before dispatching.
+        match self.validate(circuit, shots).await? {
+            ValidationResult::Invalid { reasons } => {
+                return Err(HalError::InvalidCircuit(reasons.join("; ")));
+            }
+            ValidationResult::Valid | ValidationResult::RequiresTranspilation { .. } => {}
         }
 
         // Generate job ID
@@ -420,6 +431,17 @@ mod tests {
         let circuit = Circuit::with_size("test", 10, 0);
         let result = backend.submit(&circuit, 100, None).await;
 
-        assert!(matches!(result, Err(HalError::CircuitTooLarge(_))));
+        assert!(matches!(result, Err(HalError::InvalidCircuit(_))));
+    }
+
+    #[tokio::test]
+    async fn test_simulator_validate_too_many_shots() {
+        let backend = SimulatorBackend::new();
+        let max_shots = backend.capabilities().max_shots;
+
+        let circuit = Circuit::bell().unwrap();
+        let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
+
+        assert!(matches!(result, ValidationResult::Invalid { .. }));
     }
 }

--- a/crates/arvak-grpc/tests/strict_backend.rs
+++ b/crates/arvak-grpc/tests/strict_backend.rs
@@ -86,7 +86,7 @@ impl Backend for StrictBackend {
         Ok(BackendAvailability::always_available())
     }
 
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, circuit: &Circuit, _shots: u32) -> HalResult<ValidationResult> {
         match self.validate_gates(circuit) {
             Ok(()) => Ok(ValidationResult::Valid),
             Err(rejected) => Ok(ValidationResult::Invalid {

--- a/crates/arvak-hal/src/backend.rs
+++ b/crates/arvak-hal/src/backend.rs
@@ -26,8 +26,8 @@
 //! | `name()` | sync | yes | `&str` |
 //! | `capabilities()` | sync | yes | `&Capabilities` |
 //! | `availability()` | async | yes | `HalResult<BackendAvailability>` |
-//! | `validate()` | async | yes | `HalResult<ValidationResult>` |
-//! | `submit()` | async | yes | `HalResult<JobId>` |
+//! | `validate(circuit, shots)` | async | yes | `HalResult<ValidationResult>` |
+//! | `submit(circuit, shots, parameters)` | async | yes | `HalResult<JobId>` |
 //! | `status()` | async | yes | `HalResult<JobStatus>` |
 //! | `result()` | async | yes | `HalResult<ExecutionResult>` |
 //! | `cancel()` | async | yes | `HalResult<()>` |
@@ -140,28 +140,35 @@ pub trait Backend: Send + Sync {
     /// intelligent routing decisions by schedulers.
     async fn availability(&self) -> HalResult<BackendAvailability>;
 
-    /// Validate a circuit against backend constraints.
+    /// Validate a circuit and shot count against backend constraints.
     ///
-    /// SHOULD check at minimum:
+    /// Per HAL Contract v2 §3.3 rule 3, MUST check at minimum:
     /// - Qubit count vs `capabilities().num_qubits`
+    /// - Shot count vs `capabilities().max_shots`
     /// - Gate support vs `capabilities().gate_set`
+    /// - Total operation count vs `capabilities().max_circuit_ops` (if set)
     ///
     /// Returns a three-state result: `Valid`, `Invalid`, or
     /// `RequiresTranspilation`. The third state lets an orchestrator
     /// decide to compile and retry vs. route elsewhere.
-    async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult>;
+    async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult>;
 
-    /// Submit a circuit for execution.
+    /// Submit a circuit for execution with optional parameter bindings.
     ///
     /// Returns a job ID that can be used to check status and retrieve results.
-    /// The job MUST start in `Queued` status.
-    /// Submit a circuit for execution with optional parameter bindings.
+    /// The job MUST start in `Queued` status. Per HAL Contract v2 §3.3 rule 4,
+    /// implementations MUST validate internally before dispatching and return
+    /// `HalError::InvalidCircuit` (without submitting) if validation fails.
     ///
     /// `parameters` maps OpenQASM 3.0 `input float[64]` parameter names to
     /// concrete float values.  Backends that do not support parametric circuits
     /// MUST return `HalError::Unsupported` when `parameters` is `Some(_)` with
     /// at least one entry.  Backends that do support it bind the values before
     /// dispatching to hardware.
+    ///
+    /// Note: the HAL Contract v2.3 spec models parameter binding as a separate
+    /// provided method `submit_with_parameters()`; Arvak folds it into
+    /// `submit()` directly, which is a conforming superset.
     async fn submit(
         &self,
         circuit: &Circuit,

--- a/crates/arvak-hal/src/lib.rs
+++ b/crates/arvak-hal/src/lib.rs
@@ -94,11 +94,16 @@
 //!         Ok(BackendAvailability::always_available())
 //!     }
 //!
-//!     async fn validate(&self, circuit: &Circuit) -> HalResult<ValidationResult> {
+//!     async fn validate(&self, circuit: &Circuit, shots: u32) -> HalResult<ValidationResult> {
 //!         Ok(ValidationResult::Valid)
 //!     }
 //!
-//!     async fn submit(&self, circuit: &Circuit, shots: u32) -> HalResult<JobId> {
+//!     async fn submit(
+//!         &self,
+//!         circuit: &Circuit,
+//!         shots: u32,
+//!         parameters: Option<&std::collections::HashMap<String, f64>>,
+//!     ) -> HalResult<JobId> {
 //!         // Submit circuit to hardware
 //!         # todo!()
 //!     }

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -553,12 +553,16 @@ impl PyBackend {
         Ok(a.into())
     }
 
-    /// Validate a circuit (parsed from QASM3) against backend constraints.
-    fn validate(&self, qasm: &str, py: Python<'_>) -> PyResult<PyValidationResult> {
+    /// Validate a circuit (parsed from QASM3) and shot count against
+    /// backend constraints (HAL Contract v2 §3.3 rule 3).
+    #[pyo3(signature = (qasm, shots=1024))]
+    fn validate(&self, qasm: &str, shots: u32, py: Python<'_>) -> PyResult<PyValidationResult> {
         let circuit = arvak_qasm3::parse(qasm).map_err(crate::error::parse_to_py_err)?;
         let backend = self.inner.clone();
         let v = py
-            .detach(move || runtime().block_on(async move { backend.validate(&circuit).await }))
+            .detach(move || {
+                runtime().block_on(async move { backend.validate(&circuit, shots).await })
+            })
             .map_err(hal_to_py_err)?;
         Ok(v.into())
     }

--- a/crates/arvak-sched/src/matcher.rs
+++ b/crates/arvak-sched/src/matcher.rs
@@ -304,6 +304,7 @@ mod tests {
         async fn validate(
             &self,
             _circuit: &arvak_ir::Circuit,
+            _shots: u32,
         ) -> arvak_hal::HalResult<ValidationResult> {
             Ok(ValidationResult::Valid)
         }

--- a/crates/arvak-sched/src/scheduler.rs
+++ b/crates/arvak-sched/src/scheduler.rs
@@ -714,6 +714,7 @@ mod tests {
         async fn validate(
             &self,
             _circuit: &arvak_ir::Circuit,
+            _shots: u32,
         ) -> arvak_hal::HalResult<arvak_hal::ValidationResult> {
             Ok(arvak_hal::ValidationResult::Valid)
         }

--- a/crates/arvak-sched/tests/lumi_integration.rs
+++ b/crates/arvak-sched/tests/lumi_integration.rs
@@ -51,7 +51,7 @@ impl Backend for MockHelmiBackend {
         Ok(BackendAvailability::always_available())
     }
 
-    async fn validate(&self, _circuit: &Circuit) -> HalResult<ValidationResult> {
+    async fn validate(&self, _circuit: &Circuit, _shots: u32) -> HalResult<ValidationResult> {
         Ok(ValidationResult::Valid)
     }
 


### PR DESCRIPTION
## Summary

Breaking change to the `Backend` trait: `validate()` now takes the shot count, matching HAL Contract v2.1 §3.2. This fixes the root cause behind most adapter non-conformance found in the spec audit: because shots couldn't reach `validate()`, all 12 adapters improvised inline shot checks in `submit()`, and 10 of 12 could not route `submit()` through `validate()` (rule 4) at all.

- `validate(circuit, shots)` is now the authoritative pre-flight check per rule 3: qubit count, shot count vs `max_shots`, gate support, and `max_circuit_ops` where set.
- Every adapter's `submit()` now calls `self.validate(circuit, shots)` and returns `HalError::InvalidCircuit` without dispatching when validation is `Invalid` (rule 4). Redundant inline qubit/gate checks in `submit()` were removed; precise `InvalidShots` fast-fails were kept where they existed.
- `RequiresTranspilation` still does not block submission — behavior unchanged for backends with server-side compilation.
- Python API: `Backend.validate(qasm, shots=1024)` — the default keeps existing Python callers working unchanged.
- Spec cross-references: companion spec PRs [hal-contract-spec#1](https://github.com/hiq-lab/hal-contract-spec/pull/1) (v2.2.1 consistency fixes) and [hal-contract-spec#2](https://github.com/hiq-lab/hal-contract-spec/pull/2) (v2.3 `submit_with_parameters()`); Arvak's `submit(circuit, shots, parameters)` is documented as a conforming superset of the v2.3 provided method.

## Behavior changes

- Oversized circuits submitted via `submit()` now surface as `HalError::InvalidCircuit` (from validate routing) instead of `HalError::CircuitTooLarge` in several adapters. No in-repo code relied on `CircuitTooLarge` from these paths.
- IBM's `submit()` now enforces qubit count against cached `capabilities()` (contract semantics) instead of a fresh API fetch; the live fetch remains for the operational check.

## Test plan

- [x] `cargo test --workspace --exclude arvak-python --no-fail-fast` — all green except `test_bell_state_sim_ascella` (Quandela Perceval bridge), which fails identically on unmodified `main` (missing `perceval` Python module in env; verified in a clean worktree)
- [x] New per-adapter tests: `validate()` returns `Invalid` with a shots reason when shots > `max_shots` (all 12 adapters)
- [x] `cargo clippy --workspace --exclude arvak-python --all-targets` — no new warnings (4 pre-existing in untouched `arvak-compile`)
- [x] `cargo fmt --check` — clean
- [x] Python end-to-end via `maturin develop`: `backend_for('simulator').validate(qasm, shots=10_000_000)` → `invalid, reasons=["Requested 10000000 shots but simulator supports max 100000"]`; single-arg call still valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)