### PR TITLE
feat(hal): ResultExpired job state + pin hal-contract CI checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -63,6 +64,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -86,6 +88,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -178,6 +181,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -222,6 +226,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -247,6 +252,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -281,6 +287,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -176,6 +177,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -240,6 +242,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -332,6 +335,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -438,6 +442,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust 1.85
@@ -481,6 +486,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -546,6 +552,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -598,6 +605,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -673,6 +681,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -704,6 +713,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -744,6 +754,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain
@@ -958,6 +969,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: hiq-lab/hal-contract-spec
+          ref: 0f75b14a699e7892bb4246ff019fb31edb281b35 # ref-impl v2.3 sync — bump deliberately
           path: .hal-contract
 
       - name: Install Rust toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "hal-contract"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/arvak-grpc/proto/arvak.proto
+++ b/crates/arvak-grpc/proto/arvak.proto
@@ -13,6 +13,9 @@ enum JobState {
   JOB_STATE_COMPLETED = 3;
   JOB_STATE_FAILED = 4;
   JOB_STATE_CANCELED = 5;
+  // Job completed but results were purged by the backend (HAL Contract
+  // v2.1 §5.1). Distinct from FAILED — the job ran successfully.
+  JOB_STATE_RESULT_EXPIRED = 6;
 }
 
 /// Circuit payload - supports multiple formats.

--- a/crates/arvak-grpc/src/rest/mod.rs
+++ b/crates/arvak-grpc/src/rest/mod.rs
@@ -102,6 +102,7 @@ fn job_status_string(status: &arvak_hal::job::JobStatus) -> String {
         arvak_hal::job::JobStatus::Completed => "completed".to_string(),
         arvak_hal::job::JobStatus::Failed(_) => "failed".to_string(),
         arvak_hal::job::JobStatus::Cancelled => "cancelled".to_string(),
+        arvak_hal::job::JobStatus::ResultExpired => "result_expired".to_string(),
     }
 }
 

--- a/crates/arvak-grpc/src/server/service/job_execution.rs
+++ b/crates/arvak-grpc/src/server/service/job_execution.rs
@@ -135,6 +135,7 @@ pub(super) fn to_proto_state(status: &JobStatus) -> JobState {
         JobStatus::Completed => JobState::Completed,
         JobStatus::Failed(_) => JobState::Failed,
         JobStatus::Cancelled => JobState::Canceled,
+        JobStatus::ResultExpired => JobState::ResultExpired,
     }
 }
 

--- a/crates/arvak-hal/src/backend.rs
+++ b/crates/arvak-hal/src/backend.rs
@@ -204,6 +204,9 @@ pub trait Backend: Send + Sync {
                 JobStatus::Completed => return self.result(job_id).await,
                 JobStatus::Failed(msg) => return Err(HalError::JobFailed(msg)),
                 JobStatus::Cancelled => return Err(HalError::JobCancelled),
+                JobStatus::ResultExpired => {
+                    return Err(HalError::ResultExpired(job_id.0.clone()));
+                }
                 JobStatus::Queued | JobStatus::Running => {
                     sleep(poll_interval).await;
                 }
@@ -310,5 +313,55 @@ mod tests {
             }
             .is_valid()
         );
+    }
+
+    /// Mock whose jobs are always in `ResultExpired` state.
+    struct ExpiredBackend {
+        capabilities: Capabilities,
+    }
+
+    #[async_trait]
+    impl Backend for ExpiredBackend {
+        fn name(&self) -> &str {
+            "expired"
+        }
+        fn capabilities(&self) -> &Capabilities {
+            &self.capabilities
+        }
+        async fn availability(&self) -> HalResult<BackendAvailability> {
+            Ok(BackendAvailability::always_available())
+        }
+        async fn validate(&self, _c: &Circuit, _shots: u32) -> HalResult<ValidationResult> {
+            Ok(ValidationResult::Valid)
+        }
+        async fn submit(
+            &self,
+            _c: &Circuit,
+            _shots: u32,
+            _parameters: Option<&std::collections::HashMap<String, f64>>,
+        ) -> HalResult<JobId> {
+            Ok(JobId::new("expired-job"))
+        }
+        async fn status(&self, _id: &JobId) -> HalResult<JobStatus> {
+            Ok(JobStatus::ResultExpired)
+        }
+        async fn result(&self, id: &JobId) -> HalResult<ExecutionResult> {
+            Err(crate::error::HalError::ResultExpired(id.0.clone()))
+        }
+        async fn cancel(&self, _id: &JobId) -> HalResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wait_surfaces_result_expired() {
+        let backend = ExpiredBackend {
+            capabilities: Capabilities::simulator(2),
+        };
+        let err = backend.wait(&JobId::new("expired-job")).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::HalError::ResultExpired(ref id) if id == "expired-job"
+        ));
     }
 }

--- a/crates/arvak-hal/src/capability.rs
+++ b/crates/arvak-hal/src/capability.rs
@@ -30,7 +30,7 @@ pub use hal_contract::capability::{NoiseProfile, Topology, TopologyKind};
 ///
 /// # HAL Contract v2
 ///
-/// All fields except `features` are defined by the spec.
+/// All fields are defined by the spec (§4.1, v2.1+).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Capabilities {
     /// Name of the backend.

--- a/crates/arvak-hal/src/error.rs
+++ b/crates/arvak-hal/src/error.rs
@@ -8,7 +8,7 @@
 //! |----------|----------|----------|
 //! | **Transient** | `BackendUnavailable`, `Timeout` | Retry with backoff |
 //! | **Permanent** | `InvalidCircuit`, `CircuitTooLarge`, `InvalidShots`, `Unsupported` | Fix input |
-//! | **Job-level** | `JobFailed`, `JobCancelled`, `JobNotFound` | Resubmit or abort |
+//! | **Job-level** | `SubmissionFailed`, `JobFailed`, `JobCancelled`, `JobNotFound`, `ResultExpired` | Resubmit or abort |
 //! | **Auth** | `AuthenticationFailed` | Re-authenticate |
 //! | **Config** | `Configuration`, `Backend` | Fix configuration |
 
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 /// Errors that can occur in HAL operations.
 ///
-/// All 13 spec variants are present. Arvak-specific extensions are
+/// All 14 spec variants are present. Arvak-specific extensions are
 /// grouped at the end and clearly marked.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -45,6 +45,11 @@ pub enum HalError {
     /// Job not found.
     #[error("Job not found: {0}")]
     JobNotFound(String),
+
+    /// Job completed but results were purged by the backend (terminal —
+    /// resubmit to obtain new results). See `JobStatus::ResultExpired`.
+    #[error("Result expired for job {0}")]
+    ResultExpired(String),
 
     /// Invalid circuit (permanent — fix input).
     #[error("Invalid circuit: {0}")]
@@ -118,6 +123,7 @@ impl From<hal_contract::HalError> for HalError {
             hal_contract::HalError::JobFailed(s) => Self::JobFailed(s),
             hal_contract::HalError::JobCancelled => Self::JobCancelled,
             hal_contract::HalError::JobNotFound(s) => Self::JobNotFound(s),
+            hal_contract::HalError::ResultExpired(s) => Self::ResultExpired(s),
             hal_contract::HalError::AuthenticationFailed(s) => Self::AuthenticationFailed(s),
             hal_contract::HalError::Configuration(s) => Self::Configuration(s),
             hal_contract::HalError::Backend(s) => Self::Backend(s),

--- a/crates/arvak-hal/src/job.rs
+++ b/crates/arvak-hal/src/job.rs
@@ -8,7 +8,7 @@
 //! The job state machine:
 //!
 //! ```text
-//!   submit() ──→ Queued ──→ Running ──→ Completed
+//!   submit() ──→ Queued ──→ Running ──→ Completed ──→ ResultExpired
 //!                  │           │
 //!                  │           ├──→ Failed(reason)
 //!                  │           │
@@ -16,9 +16,11 @@
 //! ```
 //!
 //! **Invariants:**
-//! - `submit()` MUST return `Queued`.
+//! - A job created by `submit()` starts in `Queued`.
 //! - Transitions are monotonic — a job never moves backward.
-//! - Terminal states (`Completed`, `Failed`, `Cancelled`) are permanent.
+//! - `Failed`, `Cancelled`, and `ResultExpired` are permanent; `Completed`
+//!   is terminal for execution but may transition to `ResultExpired` when
+//!   the backend purges results.
 //! - `result()` is only valid when status is `Completed`.
 
 // ── Re-exported from HAL Contract spec ──────────────────────────────────────

--- a/crates/arvak-python/src/backend.rs
+++ b/crates/arvak-python/src/backend.rs
@@ -308,6 +308,10 @@ impl From<JobStatus> for PyJobStatus {
                 state: "cancelled".into(),
                 message: None,
             },
+            JobStatus::ResultExpired => Self {
+                state: "result_expired".into(),
+                message: None,
+            },
         }
     }
 }
@@ -315,7 +319,10 @@ impl From<JobStatus> for PyJobStatus {
 #[pymethods]
 impl PyJobStatus {
     fn is_terminal(&self) -> bool {
-        matches!(self.state.as_str(), "completed" | "failed" | "cancelled")
+        matches!(
+            self.state.as_str(),
+            "completed" | "failed" | "cancelled" | "result_expired"
+        )
     }
 
     fn is_done(&self) -> bool {
@@ -462,6 +469,9 @@ impl PyJobHandle {
                             JobStatus::Completed => return backend.result(&job_id).await,
                             JobStatus::Failed(m) => return Err(HalError::JobFailed(m)),
                             JobStatus::Cancelled => return Err(HalError::JobCancelled),
+                            JobStatus::ResultExpired => {
+                                return Err(HalError::ResultExpired(job_id.0.clone()));
+                            }
                             JobStatus::Queued | JobStatus::Running => {
                                 if let Some(d) = deadline
                                     && Instant::now() >= d

--- a/crates/arvak-qdmi-device/src/lib.rs
+++ b/crates/arvak-qdmi-device/src/lib.rs
@@ -659,6 +659,8 @@ async unsafe fn check_job_status_async(
                 JobState::Completed => ffi::QDMI_JOB_STATUS_DONE,
                 JobState::Failed => ffi::QDMI_JOB_STATUS_FAILED,
                 JobState::Canceled => ffi::QDMI_JOB_STATUS_CANCELED,
+                // QDMI has no expired-result state; execution did complete.
+                JobState::ResultExpired => ffi::QDMI_JOB_STATUS_DONE,
                 JobState::Unspecified => ffi::QDMI_JOB_STATUS_SUBMITTED,
             };
             ffi::QDMI_SUCCESS


### PR DESCRIPTION
## Summary

Stacked on #40. Companion to [hal-contract-spec#3](https://github.com/hiq-lab/hal-contract-spec/pull/3), which syncs the reference implementations to spec v2.1–v2.3 and (breaking) adds `JobStatus::ResultExpired` to the crate Arvak re-exports.

- `HalError::ResultExpired` added — Arvak now carries all 14 spec error variants; `From<hal_contract::HalError>` maps it directly instead of falling into the `Backend` catch-all.
- `wait()` (Rust trait default and the Python-bindings wait loop) surfaces `HalError::ResultExpired`; a new arvak-hal unit test proves it with a mock backend.
- Status plumbing: REST + Python expose `"result_expired"` (terminal); gRPC proto gains `JOB_STATE_RESULT_EXPIRED = 6` (wire-compatible addition); the QDMI FFI maps it to `DONE` since QDMI has no expired-result state and execution did complete.
- **CI now pins the hal-contract-spec checkout to a SHA** in ci.yml and nightly.yml (19 checkout steps). Previously they tracked `main`, meaning any breaking change to the reference crate would break Arvak CI out from under us — exactly what spec#3 would have done. Upgrades are now deliberate pin bumps.
- Stale doc fixes: job state diagram, "13 variants" → 14, Capabilities field-provenance comment.

## Merge order

1. #40, then this PR (its CI already builds against the pinned spec#3 SHA).
2. hal-contract-spec #1 → #2 → #3 in any order afterwards — Arvak is insulated by the pin.
3. Optional later: bump the pin to the spec-repo merge commit.

## Test plan

- [x] `cargo test --workspace --exclude arvak-python --no-fail-fast` — green except the known environmental `test_bell_state_sim_ascella` (missing `perceval` module; identical on main)
- [x] New test `test_wait_surfaces_result_expired` passes
- [x] `cargo clippy --workspace --exclude arvak-python --all-targets` clean; `cargo fmt --check` clean
- [x] `cargo check -p arvak-python` clean
- [x] hal-contract 0.2.0 itself: 24 unit tests + mock example run (see spec#3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)