### PR TITLE
fix(hal,rest): rule-5 result() checks, §10 REST shape, dead axum routes

### DIFF
--- a/adapters/arvak-adapter-ddsim/src/backend.rs
+++ b/adapters/arvak-adapter-ddsim/src/backend.rs
@@ -335,8 +335,19 @@ impl Backend for DdsimBackend {
             .jobs
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        jobs.get(&job_id.0)
-            .and_then(|j| j.result.clone())
+        let ddsim_job = jobs
+            .get(&job_id.0)
+            .ok_or_else(|| HalError::JobNotFound(job_id.0.clone()))?;
+        // HAL Contract v2 §3.3 rule 5: result() is only valid in Completed.
+        if !matches!(ddsim_job.job.status, JobStatus::Completed) {
+            return Err(HalError::Backend(format!(
+                "result() called on job {} in state {} (expected Completed)",
+                job_id.0, ddsim_job.job.status
+            )));
+        }
+        ddsim_job
+            .result
+            .clone()
             .ok_or_else(|| HalError::JobNotFound(job_id.0.clone()))
     }
 

--- a/adapters/arvak-adapter-quandela/src/backend.rs
+++ b/adapters/arvak-adapter-quandela/src/backend.rs
@@ -457,6 +457,15 @@ impl Backend for QuandelaBackend {
 
     #[instrument(skip(self))]
     async fn result(&self, job_id: &JobId) -> HalResult<ExecutionResult> {
+        // HAL Contract v2 §3.3 rule 5: result() is only valid in Completed.
+        let status = self.status(job_id).await?;
+        if !matches!(status, JobStatus::Completed) {
+            return Err(HalError::Backend(format!(
+                "result() called on job {} in state {status} (expected Completed)",
+                job_id.0
+            )));
+        }
+
         let meta = cache_get(&self.job_cache, &job_id.0).await.ok_or_else(|| {
             HalError::Backend(format!(
                 "no cached circuit metadata for job {}: \

--- a/adapters/arvak-adapter-scaleway/src/backend.rs
+++ b/adapters/arvak-adapter-scaleway/src/backend.rs
@@ -551,6 +551,14 @@ impl Backend for ScalewayBackend {
             ));
         }
 
+        // HAL Contract v2 §3.3 rule 5: result() is only valid in Completed.
+        if !job_response.is_completed() {
+            return Err(HalError::Backend(format!(
+                "result() called on job {} in state {} (expected completed)",
+                job_id.0, job_response.status
+            )));
+        }
+
         // Try inline result_distribution first
         let counts = if let Some(ref dist) = job_response.result_distribution {
             let c = self.parse_result_distribution(dist);

--- a/adapters/arvak-adapter-sim/src/simulator.rs
+++ b/adapters/arvak-adapter-sim/src/simulator.rs
@@ -296,8 +296,19 @@ impl Backend for SimulatorBackend {
             .jobs
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        jobs.get(&job_id.0)
-            .and_then(|j| j.result.clone())
+        let sim_job = jobs
+            .get(&job_id.0)
+            .ok_or_else(|| HalError::JobNotFound(job_id.0.clone()))?;
+        // HAL Contract v2 §3.3 rule 5: result() is only valid in Completed.
+        if !matches!(sim_job.job.status, JobStatus::Completed) {
+            return Err(HalError::Backend(format!(
+                "result() called on job {} in state {} (expected Completed)",
+                job_id.0, sim_job.job.status
+            )));
+        }
+        sim_job
+            .result
+            .clone()
             .ok_or_else(|| HalError::JobNotFound(job_id.0.clone()))
     }
 
@@ -443,5 +454,19 @@ mod tests {
         let result = backend.validate(&circuit, max_shots + 1).await.unwrap();
 
         assert!(matches!(result, ValidationResult::Invalid { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_result_rejects_non_completed_job() {
+        let backend = SimulatorBackend::new();
+        let circuit = Circuit::bell().unwrap();
+
+        let job_id = backend.submit(&circuit, 100, None).await.unwrap();
+        backend.cancel(&job_id).await.unwrap();
+
+        // §3.3 rule 5: result() in a non-Completed state returns
+        // HalError::Backend instead of the cached result.
+        let err = backend.result(&job_id).await.unwrap_err();
+        assert!(matches!(err, HalError::Backend(ref msg) if msg.contains("Cancelled")));
     }
 }

--- a/crates/arvak-grpc/src/rest/mod.rs
+++ b/crates/arvak-grpc/src/rest/mod.rs
@@ -51,12 +51,12 @@ pub fn rest_router(state: AppState, cors_origins: &str) -> Router {
     Router::new()
         .route("/v1/health", get(health_handler))
         .route("/v1/backends", get(list_backends_handler))
-        .route("/v1/backends/{id}", get(get_backend_handler))
+        .route("/v1/backends/:id", get(get_backend_handler))
         .route("/v1/compile", post(compile_handler))
         .route("/v1/jobs", post(submit_job_handler))
-        .route("/v1/jobs/{id}", get(get_job_status_handler))
-        .route("/v1/jobs/{id}/result", get(get_job_result_handler))
-        .route("/v1/jobs/{id}", delete(cancel_job_handler))
+        .route("/v1/jobs/:id", get(get_job_status_handler))
+        .route("/v1/jobs/:id/result", get(get_job_result_handler))
+        .route("/v1/jobs/:id", delete(cancel_job_handler))
         .layer(middleware::from_fn(auth::bearer_auth))
         .layer(cors)
         .layer(axum::Extension(state.auth.clone()))
@@ -175,14 +175,18 @@ async fn get_backend_handler(
         backend_id: id,
         name: caps.name.clone(),
         is_available,
-        max_qubits: caps.num_qubits,
+        num_qubits: caps.num_qubits,
+        gate_set: caps.gate_set.clone(),
+        topology: caps.topology.clone(),
         max_shots: caps.max_shots,
-        supported_gates,
-        topology_json,
-        noise_profile_json,
         max_circuit_ops: caps.max_circuit_ops,
         is_simulator: caps.is_simulator,
         features: caps.features.clone(),
+        noise_profile: caps.noise_profile.clone(),
+        max_qubits: caps.num_qubits,
+        supported_gates,
+        topology_json,
+        noise_profile_json,
     }))
 }
 

--- a/crates/arvak-grpc/src/rest/types.rs
+++ b/crates/arvak-grpc/src/rest/types.rs
@@ -71,23 +71,35 @@ pub struct ListBackendsResponse {
 }
 
 /// GET /v1/backends/{id}
+///
+/// The `num_qubits`, `gate_set`, `topology`, and `noise_profile` fields
+/// follow HAL Contract v2 §10 / §4.1 (structured JSON). The flat
+/// `max_qubits` / `supported_gates` / `*_json` fields predate that shape
+/// and are kept for backward compatibility — prefer the structured ones.
 #[derive(Debug, Serialize)]
 pub struct BackendDetailResponse {
     pub backend_id: String,
     pub name: String,
     pub is_available: bool,
-    pub max_qubits: u32,
+    // ── HAL Contract v2 §4.1 shape ────────────────────────────────
+    pub num_qubits: u32,
+    pub gate_set: arvak_hal::capability::GateSet,
+    pub topology: arvak_hal::capability::Topology,
     pub max_shots: u32,
-    pub supported_gates: Vec<String>,
-    pub topology_json: String,
-    /// Device-wide noise averages; `null` when unavailable (DEBT-24).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub noise_profile_json: Option<String>,
     /// Maximum gate operations per circuit; `null` = no limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_circuit_ops: Option<u32>,
     pub is_simulator: bool,
     pub features: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub noise_profile: Option<arvak_hal::capability::NoiseProfile>,
+    // ── Legacy flat fields (pre-§10; deprecated) ──────────────────
+    pub max_qubits: u32,
+    pub supported_gates: Vec<String>,
+    pub topology_json: String,
+    /// Device-wide noise averages; `null` when unavailable (DEBT-24).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub noise_profile_json: Option<String>,
 }
 
 /// POST /v1/compile response


### PR DESCRIPTION
## Summary

Stacked on #41 (→ #40). Closes the last items from the HAL Contract v2 audit, plus one significant bug found while verifying.

**Rule 5 — `result()` on non-Completed jobs (§3.3):**
- **sim** and **ddsim** returned the cached result without any status check; they now return `HalError::Backend` with the job's actual state. Regression test: submit → cancel → `result()` errors.
- **quandela** forwarded to the Perceval bridge blindly; it now checks `status()` first.
- **scaleway** only checked for failure; it now also requires `is_completed()` before parsing results.

**§10 REST alignment — `GET /v1/backends/{id}`:**
Response now carries the spec-shaped structured fields (`num_qubits`, `gate_set{single_qubit,two_qubit,three_qubit,native}`, `topology{kind,edges}`, `noise_profile`, `max_circuit_ops`) alongside the legacy flat fields (`max_qubits`, `supported_gates`, `topology_json`, `noise_profile_json`), which remain for backward compatibility and are documented as deprecated. No in-repo consumer parses the legacy REST fields (the Python grpc-client reads the *proto* shape).

**Bug: every parameterized REST route was dead.**
arvak-grpc pins axum 0.7, where path parameters are `:id` — the routes were declared with the axum-0.8 `{id}` syntax, so `/v1/backends/{id}`, `GET|DELETE /v1/jobs/{id}`, and `/v1/jobs/{id}/result` only matched the literal string and always returned an empty 404. These endpoints can never have worked since they were written.

## Verified live (not just tests)

Ran `arvak-rest-gateway` and exercised the full lifecycle over HTTP:
- `GET /v1/backends/simulator` → 200 with structured `gate_set`/`topology` + legacy fields (was: empty 404)
- `POST /v1/jobs` (Bell circuit, 1000 shots) → `GET /v1/jobs/{id}` → `"completed"` → `GET /v1/jobs/{id}/result` → `{"11":528,"00":472}` → `DELETE` correctly refuses on terminal job

Plus: `cargo test --workspace --exclude arvak-python --no-fail-fast` green except the known environmental `test_bell_state_sim_ascella` (fails at submit inside the Perceval bridge, before the code changed here); clippy + fmt clean.

## Follow-up candidates (not in this PR)

- Upgrade arvak-grpc to axum 0.8 (workspace already ships 0.8 elsewhere) and return to `{id}` syntax.
- An integration test that spins up the REST router and asserts route matching, so dead routes can't recur silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)