### PR TITLE
Clean up stale references and unify adapter workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,18 +29,21 @@ arvak-hal = { path = "crates/arvak-hal" }
 arvak-sched = { path = "crates/arvak-sched" }
 arvak-types = { path = "crates/arvak-types" }
 arvak-auto = { path = "crates/arvak-auto" }
-arvak-dashboard = { path = "crates/arvak-dashboard" }
-arvak-bench = { path = "crates/arvak-bench" }
 arvak-eval = { path = "crates/arvak-eval" }
 arvak-sim = { path = "crates/arvak-sim" }
 
 # Adapter crates
 arvak-adapter-sim = { path = "adapters/arvak-adapter-sim" }
 arvak-adapter-ddsim = { path = "adapters/arvak-adapter-ddsim" }
+arvak-adapter-aqt = { path = "adapters/arvak-adapter-aqt" }
 arvak-adapter-braket = { path = "adapters/arvak-adapter-braket" }
 arvak-adapter-cudaq = { path = "adapters/arvak-adapter-cudaq" }
+arvak-adapter-ibm = { path = "adapters/arvak-adapter-ibm" }
 arvak-adapter-ionq = { path = "adapters/arvak-adapter-ionq" }
+arvak-adapter-iqm = { path = "adapters/arvak-adapter-iqm" }
 arvak-adapter-quandela = { path = "adapters/arvak-adapter-quandela" }
+arvak-adapter-quantinuum = { path = "adapters/arvak-adapter-quantinuum" }
+arvak-adapter-scaleway = { path = "adapters/arvak-adapter-scaleway" }
 
 # Async runtime — minimal workspace features; crates add extras as needed.
 tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Arvak is **not** a Qiskit/Cirq/Qrisp replacement. It's a thin Rust HAL that sits
                               │
 ┌─────────────────────────────▼───────────────────────────────────────────────────┐
 │                         Backend Adapters + Plugin System                         │
-│  Sim │ IQM │ IBM │ Quantinuum │ AQT │ Quandela │ DDSIM │ Braket │ CUDA-Q │ QDMI │
+│  Sim │ IQM │ IBM │ Quantinuum │ AQT │ IonQ │ Quandela │ Scaleway │ DDSIM │ Braket │ CUDA-Q │ QDMI │
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -557,12 +557,11 @@ arvak/
 │   ├── arvak-eval/        # Evaluator: compilation observability, QDMI contracts, emitter compliance
 │   ├── arvak-sched/       # HPC job scheduler (SLURM, PBS, workflows, routing)
 │   ├── arvak-dashboard/   # Web dashboard for visualization & monitoring
-│   ├── arvak-proj/        # MPS tensor-network circuit projection (large-qubit simulation)
 │   ├── arvak-bench/       # Benchmark suite (QV, CLOPS, Randomized Benchmarking)
 │   ├── arvak-types/       # Qrisp-like quantum types (QuantumInt, QuantumFloat)
 │   └── arvak-auto/        # Automatic uncomputation
 ├── grpc-client/
-│   └── arvak_grpc/        # gRPC Python client (v1.8.0)
+│   └── arvak_grpc/        # gRPC Python client (v1.6.0)
 │       ├── client.py               # Sync client
 │       ├── async_client.py         # Async client with connection pooling
 │       ├── job_future.py           # Promise-like job interface
@@ -581,6 +580,7 @@ arvak/
 │   ├── arvak-adapter-ibm/        # IBM Quantum API adapter
 │   ├── arvak-adapter-quantinuum/ # Quantinuum H1/H2 trapped-ion adapter
 │   ├── arvak-adapter-aqt/        # AQT trapped-ion adapter
+│   ├── arvak-adapter-ionq/       # IonQ trapped-ion adapter
 │   ├── arvak-adapter-quandela/   # Quandela photonic adapter
 │   ├── arvak-adapter-scaleway/   # Scaleway QaaS adapter (IQM hardware)
 │   ├── arvak-adapter-braket/     # AWS Braket adapter
@@ -588,8 +588,7 @@ arvak/
 │   └── arvak-adapter-qdmi/       # QDMI (Munich Quantum Software Stack) adapter
 ├── demos/               # Demo applications
 │   ├── bin/             # Grover, VQE, QAOA, QI-Nutshell, speed benchmarks
-│   ├── src/             # Shared circuits, problems, runners
-│   └── lumi-hybrid/     # LUMI quantum-HPC hybrid VQE demo
+│   └── src/             # Shared circuits, problems, runners
 └── examples/            # Example QASM circuits
 ```
 
@@ -890,31 +889,6 @@ cargo run --bin demo-speed-qaoa
 ```
 
 Each demo reports per-circuit compile times, gates/s throughput, and speedup vs. a 100ms/circuit baseline.
-
-### LUMI Hybrid VQE Demo
-
-Complete quantum-HPC hybrid workflow using VQE for H₂ molecule ground state energy:
-
-```bash
-# Local simulation
-cargo run -p lumi-hybrid -- --shots 1000 --iterations 20
-
-# Bond distance scan
-cargo run -p lumi-hybrid -- --mode bond-scan --start 0.5 --end 2.0 --points 10
-
-# On LUMI (via SLURM)
-cd demos/lumi-hybrid
-sbatch slurm/vqe_workflow.sh
-```
-
-**Features:**
-- UCCSD ansatz for H₂ molecule
-- Jordan-Wigner transformed Hamiltonian
-- Nelder-Mead optimizer (converges to chemical accuracy)
-- SLURM job scripts for LUMI-G (GPU) and LUMI-Q (quantum)
-- Python visualization for results
-
-See [demos/lumi-hybrid/README.md](demos/lumi-hybrid/README.md) for detailed setup.
 
 ## Web Dashboard
 

--- a/audit.toml
+++ b/audit.toml
@@ -54,26 +54,4 @@ ignore = [
     #   Same as RUSTSEC-2026-0176 — bump pyo3 to >= 0.29.0 once the
     #   Rust toolchain in CI supports it.
     "RUSTSEC-2026-0177",
-
-    # ----------------------------------------------------------------
-    # RUSTSEC-2024-0436 — paste crate is no longer maintained.
-    # Severity: informational/unmaintained (not a vulnerability —
-    # cargo audit exits 0 with this present, but listing it here keeps
-    # the warning count at zero for clean CI summaries).
-    #
-    # Why ignored:
-    #   paste is a transitive proc-macro dep we never use directly. It
-    #   is pulled in through gemm (matrix multiplication kernels) ->
-    #   faer (tensor network linear algebra) -> arvak-proj. Upstream
-    #   gemm/pulp/faer would need to migrate to a maintained
-    #   alternative (e.g. pastey or std `concat_idents!` once it
-    #   stabilises). Confirmed via `cargo tree --invert paste` on
-    #   2026-06-24 that we have no direct use.
-    #
-    # Removal path:
-    #   When faer/gemm/pulp drop the paste dependency (track gemm
-    #   upstream at https://github.com/sarah-quinones/gemm). Once
-    #   `cargo tree --invert paste` returns no matches in this
-    #   workspace, delete this entry.
-    "RUSTSEC-2024-0436",
 ]

--- a/crates/arvak-cli/Cargo.toml
+++ b/crates/arvak-cli/Cargo.toml
@@ -18,14 +18,14 @@ arvak-ir = { workspace = true }
 arvak-qasm3 = { workspace = true }
 arvak-compile = { workspace = true }
 arvak-hal = { workspace = true }
-arvak-adapter-sim = { path = "../../adapters/arvak-adapter-sim" }
-arvak-adapter-ddsim = { path = "../../adapters/arvak-adapter-ddsim", optional = true }
-arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
-arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
-arvak-adapter-braket = { path = "../../adapters/arvak-adapter-braket", optional = true }
-arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
-arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
-arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
+arvak-adapter-sim = { workspace = true }
+arvak-adapter-ddsim = { workspace = true, optional = true }
+arvak-adapter-iqm = { workspace = true, optional = true }
+arvak-adapter-ibm = { workspace = true, optional = true }
+arvak-adapter-braket = { workspace = true, optional = true }
+arvak-adapter-scaleway = { workspace = true, optional = true }
+arvak-adapter-quantinuum = { workspace = true, optional = true }
+arvak-adapter-aqt = { workspace = true, optional = true }
 arvak-sched = { workspace = true }
 arvak-eval = { workspace = true }
 

--- a/crates/arvak-grpc/Cargo.toml
+++ b/crates/arvak-grpc/Cargo.toml
@@ -30,11 +30,11 @@ arvak-qasm3 = { workspace = true }
 arvak-types = { workspace = true }
 
 # Arvak backends (feature-gated)
-arvak-adapter-sim = { path = "../../adapters/arvak-adapter-sim", optional = true }
-arvak-adapter-braket = { path = "../../adapters/arvak-adapter-braket", optional = true }
-arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
-arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
-arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
+arvak-adapter-sim = { workspace = true, optional = true }
+arvak-adapter-braket = { workspace = true, optional = true }
+arvak-adapter-ibm = { workspace = true, optional = true }
+arvak-adapter-quantinuum = { workspace = true, optional = true }
+arvak-adapter-aqt = { workspace = true, optional = true }
 arvak-adapter-quandela = { workspace = true, optional = true }
 
 # Storage backends (feature-gated)

--- a/crates/arvak-python/Cargo.toml
+++ b/crates/arvak-python/Cargo.toml
@@ -31,12 +31,12 @@ arvak-compile = { workspace = true }
 arvak-qasm3 = { workspace = true }
 arvak-hal = { workspace = true }
 arvak-adapter-sim = { workspace = true, optional = true }
-arvak-adapter-iqm = { path = "../../adapters/arvak-adapter-iqm", optional = true }
-arvak-adapter-scaleway = { path = "../../adapters/arvak-adapter-scaleway", optional = true }
-arvak-adapter-ibm = { path = "../../adapters/arvak-adapter-ibm", optional = true }
-arvak-adapter-quantinuum = { path = "../../adapters/arvak-adapter-quantinuum", optional = true }
-arvak-adapter-aqt = { path = "../../adapters/arvak-adapter-aqt", optional = true }
-arvak-adapter-ionq = { path = "../../adapters/arvak-adapter-ionq", optional = true }
+arvak-adapter-iqm = { workspace = true, optional = true }
+arvak-adapter-scaleway = { workspace = true, optional = true }
+arvak-adapter-ibm = { workspace = true, optional = true }
+arvak-adapter-quantinuum = { workspace = true, optional = true }
+arvak-adapter-aqt = { workspace = true, optional = true }
+arvak-adapter-ionq = { workspace = true, optional = true }
 arvak-adapter-quandela = { workspace = true, optional = true }
 arvak-adapter-braket = { workspace = true, optional = true }
 arvak-adapter-cudaq = { workspace = true, optional = true }

--- a/docs/code-specification.md
+++ b/docs/code-specification.md
@@ -17,7 +17,7 @@ version = "1.0.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
-repository = "https://github.com/arvak-project/arvak"
+repository = "https://github.com/hiq-lab/arvak"
 keywords = ["quantum", "hpc", "compiler", "qasm", "orchestration"]
 categories = ["science", "compilers", "simulation"]
 

--- a/docs/hpc-deployment.md
+++ b/docs/hpc-deployment.md
@@ -196,7 +196,7 @@ backend:
 
 ```bash
 # Download release binary
-curl -LO https://github.com/arvak-project/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
+curl -LO https://github.com/hiq-lab/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
 
 # Extract
 tar xzf arvak-linux-x86_64.tar.gz
@@ -216,7 +216,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 module load rust/1.83
 
 # Clone and build
-git clone https://github.com/arvak-project/arvak
+git clone https://github.com/hiq-lab/arvak
 cd arvak
 cargo build --release
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@
 
 ```bash
 # Download latest release
-curl -LO https://github.com/arvak-project/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
+curl -LO https://github.com/hiq-lab/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
 
 # Extract
 tar xzf arvak-linux-x86_64.tar.gz
@@ -25,7 +25,7 @@ arvak --version
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Clone and build
-git clone https://github.com/arvak-project/arvak
+git clone https://github.com/hiq-lab/arvak
 cd arvak
 cargo build --release
 
@@ -278,5 +278,5 @@ arvak -vvv submit -i circuit.qasm --backend iqm
 ```
 
 For issues and questions:
-- GitHub Issues: https://github.com/arvak-project/arvak/issues
-- Documentation: https://arvak-project.github.io/arvak/
+- GitHub Issues: https://github.com/hiq-lab/arvak/issues
+- Documentation: https://hiq-lab.github.io/arvak/


### PR DESCRIPTION
## What changed

Structural cleanup pass over docs and workspace manifests. Two commits:

**docs (`12b3be4`)**
- Removed `arvak-proj` from the README structure tree — the crate was extracted to the standalone Huoma project and no longer exists in this repo.
- Removed the LUMI Hybrid VQE Demo section and all five references to `demos/lumi-hybrid/`, which does not exist.
- Fixed 7 GitHub URLs in `docs/quickstart.md`, `docs/hpc-deployment.md`, and `docs/code-specification.md` pointing at the wrong org (`arvak-project` → `hiq-lab`).
- Corrected the grpc-client version note in the README (claimed v1.8.0; `grpc-client/setup.py` says 1.6.0).
- Added the missing IonQ and Scaleway adapters to the README architecture diagram and adapter tree (all 12 adapters now listed).

**chore (`9c8195e`)**
- Adapter dependencies were referenced inconsistently: 6 adapters via `[workspace.dependencies]`, the other 6 via raw `path = "../../..."` deps scattered across arvak-cli, arvak-grpc, and arvak-python. Added the missing adapters (aqt, ibm, iqm, quantinuum, scaleway) to `[workspace.dependencies]` and converted all consumers to `workspace = true`. Resolution-identical — `Cargo.lock` is unchanged.
- Removed `arvak-dashboard` and `arvak-bench` from `[workspace.dependencies]`; no member crate references either.
- Deleted the RUSTSEC-2024-0436 (`paste`) exemption from `audit.toml`. Its own removal note said to drop it once `paste` left the dependency tree — that happened when arvak-proj was extracted. Verified: `cargo tree --invert paste` returns no matches.

## Why

Leftover references from the arvak-proj → Huoma extraction, plus manifest drift that made adapter versioning inconsistent across consumer crates.

## Reviewer notes

- `cargo check -p arvak-cli --features iqm,ibm,braket,scaleway,quantinuum,aqt` and `cargo check -p arvak-grpc --features simulator,braket,ibm,quantinuum,aqt,quandela` both pass.
- `cargo audit` invoked exactly as CI does (ignore args parsed from `audit.toml`) exits 0 with the two remaining pyo3 exemptions.
- `scripts/audit.sh` passes: 16 passed, 0 failed (6 pre-existing heuristic warnings in the backend-table matcher, unrelated).
- Deliberately untouched: the QDMI adapter stays out of consumer manifests (registry integration is the documented Phase 12 item), the `demos/*_test.py` QPU smoke scripts are intentional, and grpc-client keeps its independent 1.6.0 versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)