### PR TITLE
docs: concise user documentation with CI-tested snippets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,14 @@ jobs:
       - name: Build Python bindings
         run: cd crates/arvak-python && maturin build
 
+      - name: Test documentation snippets
+        # Executes every ```python block in docs/quickstart.md and
+        # docs/python-api.md against the freshly built bindings, so
+        # published examples can never drift from the real API again.
+        run: |
+          pip install pytest target/wheels/*.whl
+          pytest crates/arvak-python/tests/test_doc_snippets.py -q
+
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1317,7 +1317,7 @@ Arvak is developed and maintained by **[The HAL Contract](https://www.hal-contra
 
 - **GitHub Repository**: [github.com/hiq-lab/arvak](https://github.com/hiq-lab/arvak)
 - **GitHub Issues**: [github.com/hiq-lab/arvak/issues](https://github.com/hiq-lab/arvak/issues)
-- **Documentation**: [docs/](docs/)
+- **Documentation**: [docs/README.md](docs/README.md) — quickstart, Python API, CLI reference
 - **PyPI Package**: [pypi.org/project/arvak](https://pypi.org/project/arvak/)
 
 ### Collaboration & Partnership

--- a/crates/arvak-python/tests/test_doc_snippets.py
+++ b/crates/arvak-python/tests/test_doc_snippets.py
@@ -1,0 +1,43 @@
+"""Execute every ```python code block in the user-facing docs.
+
+This is the guard against documentation drift: the IQM review (2026-07)
+found that published snippets used an API that never existed. Any snippet
+readable in docs/quickstart.md or docs/python-api.md is guaranteed to run
+against the current bindings, or this test fails.
+
+Blocks that cannot run in CI (vendor credentials, optional extras) must
+carry a `# doc-test: skip` marker with the reason on the same line.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+DOCS = Path(__file__).resolve().parents[3] / "docs"
+DOC_FILES = ["quickstart.md", "python-api.md"]
+
+BLOCK_RE = re.compile(r"```python\n(.*?)```", re.S)
+
+
+def _snippets():
+    for name in DOC_FILES:
+        path = DOCS / name
+        if not path.exists():
+            yield pytest.param(
+                None, id=f"{name}#missing", marks=pytest.mark.xfail(reason="doc file missing")
+            )
+            continue
+        for i, match in enumerate(BLOCK_RE.finditer(path.read_text(encoding="utf-8"))):
+            code = match.group(1)
+            marks = []
+            if "# doc-test: skip" in code:
+                marks.append(pytest.mark.skip(reason="marked doc-test: skip"))
+            yield pytest.param(code, id=f"{name}#{i}", marks=marks)
+
+
+@pytest.mark.parametrize("code", _snippets())
+def test_doc_snippet_executes(code):
+    # Each block must be self-contained (its own imports) — that is also
+    # what makes it copy-pasteable for readers.
+    exec(compile(code, "<doc-snippet>", "exec"), {"__name__": "__doc_snippet__"})

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# Arvak Documentation
+
+## Using Arvak
+
+| Doc | What it covers |
+|-----|----------------|
+| [Quick Start](quickstart.md) | Install, first circuit in Python / CLI / Rust, hardware submission |
+| [Python API Reference](python-api.md) | `Circuit`, `run_sim`, `compile`, backends, QASM 3 I/O, integrations |
+| [CLI Reference](cli.md) | All `arvak` commands and flags (generated from `--help`) |
+| [HPC Deployment](hpc-deployment.md) | SLURM/PBS submission, OIDC auth, LUMI/LRZ |
+
+## Extending Arvak
+
+| Doc | What it covers |
+|-----|----------------|
+| [Integration Guide](INTEGRATION_GUIDE.md) | Adding a framework integration (Qiskit/Qrisp/Cirq/PennyLane pattern) |
+| [HAL Contract](hal-contract.md) | The backend abstraction every adapter implements |
+| [HAL Specification](hal-specification.md) | Formal HAL semantics |
+
+## Internals
+
+| Doc | What it covers |
+|-----|----------------|
+| [Architecture](architecture.md) | Crate layout, data flow, design decisions |
+| [Compilation Pipeline](compilation.md) | Passes, optimization levels, layout/routing/translation |
+| [IR Specification](ir-specification.md) | Circuit DAG representation |
+| [Code Specification](code-specification.md) | Conventions for contributors |
+| [Release Process](release-process.md) | Versioning, tagging, PyPI publishing |
+
+## How this documentation stays correct
+
+- **Python snippets are CI-tested.** Every ` ```python ` block in
+  `quickstart.md` and `python-api.md` is executed by
+  [`test_doc_snippets.py`](../crates/arvak-python/tests/test_doc_snippets.py)
+  in the Python Bindings CI job. Blocks that need credentials or optional
+  extras carry a `# doc-test: skip` marker with the reason.
+- **The CLI reference is generated**, not written: rerun
+  [`scripts/gen-cli-docs.sh`](../scripts/gen-cli-docs.sh) after CLI changes.
+- **Keep prose thin.** Reference the code for details that would go stale;
+  document behavior, defaults, and intent — not signatures the docstrings
+  already carry.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,196 @@
+# CLI Reference
+
+> Generated from `arvak --help` by [`scripts/gen-cli-docs.sh`](../scripts/gen-cli-docs.sh).
+> Do not edit by hand — rerun the script after CLI changes.
+
+```text
+Arvak command-line interface
+
+Usage: arvak [OPTIONS] <COMMAND>
+
+Commands:
+  compile   Compile a quantum circuit for a target backend
+  run       Run a circuit on a backend
+  submit    Submit a circuit to an HPC batch scheduler
+  status    Query job status
+  result    Retrieve results for a completed job
+  auth      Manage authentication for HPC providers
+  wait      Wait for a job to complete
+  eval      Evaluate a circuit: compilation observability, QDMI contract check, metrics
+  backends  List available backends
+  version   Show version information
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Increase verbosity (-v, -vv, -vvv)
+  -h, --help        Print help
+  -V, --version     Print version
+```
+
+## arvak compile
+
+```text
+Compile a quantum circuit for a target backend
+
+Usage: arvak compile [OPTIONS] --input <INPUT>
+
+Options:
+  -i, --input <INPUT>                            Input file (QASM3 or JSON)
+  -v, --verbose...                               Increase verbosity (-v, -vv, -vvv)
+  -o, --output <OUTPUT>                          Output file
+  -t, --target <TARGET>                          Target backend (iqm, ibm, simulator) [default: iqm]
+      --optimization-level <OPTIMIZATION_LEVEL>  Optimization level (0-3) [default: 1]
+  -h, --help                                     Print help
+```
+
+## arvak run
+
+```text
+Run a circuit on a backend
+
+Usage: arvak run [OPTIONS] --input <INPUT>
+
+Options:
+  -i, --input <INPUT>      Input file (QASM3 or JSON)
+  -v, --verbose...         Increase verbosity (-v, -vv, -vvv)
+  -s, --shots <SHOTS>      Number of shots [default: 1024]
+  -b, --backend <BACKEND>  Backend to use [default: simulator]
+      --compile            Compile before running
+      --target <TARGET>    Target for compilation
+  -h, --help               Print help
+```
+
+## arvak submit
+
+```text
+Submit a circuit to an HPC batch scheduler
+
+Usage: arvak submit [OPTIONS] --input <INPUT>
+
+Options:
+  -i, --input <INPUT>          Input file (QASM3 or JSON)
+  -v, --verbose...             Increase verbosity (-v, -vv, -vvv)
+  -b, --backend <BACKEND>      Backend to use (simulator, iqm, ibm) [default: simulator]
+  -s, --shots <SHOTS>          Number of shots [default: 1024]
+      --scheduler <SCHEDULER>  Batch scheduler (slurm, pbs) [default: slurm]
+      --partition <PARTITION>  Scheduler partition/queue name
+      --account <ACCOUNT>      Scheduler account/project
+      --time <TIME>            Wall time limit (HH:MM:SS)
+      --priority <PRIORITY>    Job priority (low, default, high, critical)
+  -w, --wait                   Wait for job to complete
+  -h, --help                   Print help
+```
+
+## arvak status
+
+```text
+Query job status
+
+Usage: arvak status [OPTIONS] [JOB_ID]
+
+Arguments:
+  [JOB_ID]  Job ID (UUID)
+
+Options:
+  -a, --all         List all jobs
+  -v, --verbose...  Increase verbosity (-v, -vv, -vvv)
+  -h, --help        Print help
+```
+
+## arvak result
+
+```text
+Retrieve results for a completed job
+
+Usage: arvak result [OPTIONS] <JOB_ID>
+
+Arguments:
+  <JOB_ID>  Job ID (UUID)
+
+Options:
+  -f, --format <FORMAT>  Output format (table, json) [default: table]
+  -v, --verbose...       Increase verbosity (-v, -vv, -vvv)
+  -h, --help             Print help
+```
+
+## arvak auth
+
+```text
+Manage authentication for HPC providers
+
+Usage: arvak auth [OPTIONS] <COMMAND>
+
+Commands:
+  login   Log in to an HPC provider
+  status  Show authentication status
+  logout  Log out and clear cached tokens
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Increase verbosity (-v, -vv, -vvv)
+  -h, --help        Print help
+```
+
+## arvak wait
+
+```text
+Wait for a job to complete
+
+Usage: arvak wait [OPTIONS] <JOB_ID>
+
+Arguments:
+  <JOB_ID>  Job ID (UUID)
+
+Options:
+  -t, --timeout <TIMEOUT>  Timeout in seconds [default: 86400]
+  -v, --verbose...         Increase verbosity (-v, -vv, -vvv)
+  -h, --help               Print help
+```
+
+## arvak eval
+
+```text
+Evaluate a circuit: compilation observability, QDMI contract check, metrics
+
+Usage: arvak eval [OPTIONS] --input <INPUT>
+
+Options:
+  -i, --input <INPUT>
+          Input file (QASM3)
+  -v, --verbose...
+          Increase verbosity (-v, -vv, -vvv)
+  -p, --profile <PROFILE>
+          Evaluation profile [default: default]
+  -t, --target <TARGET>
+          Target backend (iqm, ibm, simulator) [default: iqm]
+      --optimization-level <OPTIMIZATION_LEVEL>
+          Optimization level (0-3) [default: 1]
+      --target-qubits <TARGET_QUBITS>
+          Number of qubits on target device [default: 20]
+  -e, --export <EXPORT>
+          Output file for JSON report (stdout if omitted)
+      --orchestration
+          Include orchestration analysis (hybrid DAG, batchability, critical path)
+      --scheduler-site <SCHEDULER_SITE>
+          HPC scheduler site for constraints (lrz, lumi)
+      --emit <EMIT>
+          Emitter compliance target (iqm, ibm, cuda-q)
+      --benchmark <BENCHMARK>
+          Optional benchmark workload (ghz, qft, grover, random)
+      --benchmark-qubits <BENCHMARK_QUBITS>
+          Number of qubits for benchmark circuit (defaults to input circuit size)
+  -h, --help
+          Print help
+```
+
+## arvak backends
+
+```text
+List available backends
+
+Usage: arvak backends [OPTIONS]
+
+Options:
+  -v, --verbose...  Increase verbosity (-v, -vv, -vvv)
+  -h, --help        Print help
+```

--- a/docs/hpc-deployment.md
+++ b/docs/hpc-deployment.md
@@ -1,454 +1,124 @@
-# Arvak HPC Deployment Guide
+# HPC Deployment Guide
 
-## Overview
+Arvak submits quantum jobs through HPC batch schedulers (SLURM and
+PBS/Torque) so that QPU access follows the same workflow as classical
+HPC workloads: `arvak submit` renders a batch script, the scheduler
+queues it, and Arvak tracks the job through to results.
 
-Arvak is designed for deployment in High-Performance Computing (HPC) environments, with first-class support for job schedulers like Slurm and PBS. This guide covers deployment at HPC centers with quantum computing resources.
+All CLI flags shown here are real — regenerate the full reference with
+[`scripts/gen-cli-docs.sh`](../scripts/gen-cli-docs.sh) or check
+`arvak submit --help`.
 
-## Architecture in HPC Context
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                              HPC Center                                      │
-│                                                                             │
-│  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │                         Login Node                                   │   │
-│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────────────┐   │   │
-│  │  │  User CLI   │────▶│  Arvak Core   │────▶│  Scheduler Adapter  │   │   │
-│  │  │  (arvak)      │     │             │     │  (Slurm/PBS)        │   │   │
-│  │  └─────────────┘     └─────────────┘     └──────────┬──────────┘   │   │
-│  └──────────────────────────────────────────────────────┼──────────────┘   │
-│                                                         │                   │
-│                                                         ▼                   │
-│  ┌──────────────────────────────────────────────────────────────────────┐  │
-│  │                      Job Scheduler (Slurm)                            │  │
-│  │  ┌────────────────────────────────────────────────────────────────┐  │  │
-│  │  │  Job Queue                                                      │  │  │
-│  │  │  - quantum partition                                            │  │  │
-│  │  │  - standard partitions                                          │  │  │
-│  │  └────────────────────────────────────────────────────────────────┘  │  │
-│  └──────────────────────────────────────────────────────┬───────────────┘  │
-│                                                         │                   │
-│                                                         ▼                   │
-│  ┌──────────────────────────────────────────────────────────────────────┐  │
-│  │                       Compute Node                                    │  │
-│  │  ┌─────────────────┐                      ┌────────────────────┐     │  │
-│  │  │   arvak-runner    │─────────────────────▶│   Quantum System   │     │  │
-│  │  │                 │                      │   (IQM/IBM)        │     │  │
-│  │  └─────────────────┘                      └────────────────────┘     │  │
-│  └──────────────────────────────────────────────────────────────────────┘  │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
-## Scheduler Integration
-
-### Slurm Adapter
-
-The Slurm adapter generates and submits sbatch scripts.
-
-```rust
-pub struct SlurmAdapter {
-    config: SlurmConfig,
-}
-
-pub struct SlurmConfig {
-    pub partition: String,
-    pub account: String,
-    pub default_walltime: Duration,
-    pub qos: Option<String>,
-    pub constraint: Option<String>,
-}
-
-#[async_trait]
-impl Scheduler for SlurmAdapter {
-    async fn submit(&self, job: &QuantumJob) -> SchedulerResult<SchedulerJobId>;
-    async fn status(&self, job_id: &SchedulerJobId) -> SchedulerResult<SchedulerStatus>;
-    async fn cancel(&self, job_id: &SchedulerJobId) -> SchedulerResult<()>;
-    async fn output(&self, job_id: &SchedulerJobId) -> SchedulerResult<JobOutput>;
-}
-```
-
-### Generated Slurm Script
+## Installation on a login node
 
 ```bash
-#!/bin/bash
-#SBATCH --job-name=arvak-job
-#SBATCH --partition=q_fiqci
-#SBATCH --account=project_462000xxx
-#SBATCH --time=00:30:00
-#SBATCH --nodes=1
-#SBATCH --ntasks=1
-#SBATCH --output=arvak_%j.out
-#SBATCH --error=arvak_%j.err
+# Python API
+pip install --user arvak
 
-# Load required modules
-module load iqm-client
-
-# Set environment
-export ARVAK_JOB_ID="${ARVAK_JOB_ID}"
-export ARVAK_BACKEND="${ARVAK_BACKEND}"
-
-# Run the quantum job
-arvak-runner --job-id="${ARVAK_JOB_ID}"
+# CLI from source (hal-contract is a workspace path dependency)
+git clone https://github.com/hiq-lab/arvak
+git clone https://github.com/hiq-lab/hal-contract
+cd arvak && ln -s ../hal-contract .hal-contract
+cargo install --path crates/arvak-cli
 ```
 
-### PBS Adapter
+## Authentication
 
-Similar interface for PBS Pro environments.
+OIDC login for supported HPC providers:
 
-```rust
-pub struct PbsAdapter {
-    config: PbsConfig,
-}
-
-pub struct PbsConfig {
-    pub queue: String,
-    pub account: String,
-    pub default_walltime: Duration,
-}
+```bash
+arvak auth login --provider csc      # csc, lumi, lrz
+arvak auth status
+arvak auth logout
 ```
 
-## Site-Specific Configuration
+Vendor tokens are read from environment variables:
+
+| Variable | Backend |
+|----------|---------|
+| `IQM_TOKEN` | IQM (Resonance / on-premise) |
+| `IBM_QUANTUM_TOKEN`, `IBM_API_KEY`, `IBM_SERVICE_CRN` | IBM Quantum |
+| `ARVAK_STATE_DIR` | Override scheduler state directory (default: `$XDG_RUNTIME_DIR/arvak-scheduler`) |
+
+Never hardcode tokens in job scripts; export them in your shell profile
+or use the OIDC flow.
+
+## Submitting jobs
+
+Compile locally first to catch errors before queueing:
+
+```bash
+arvak compile -i circuit.qasm --target iqm \
+    --optimization-level 2 -o compiled.qasm
+```
+
+Submit through the scheduler:
+
+```bash
+arvak submit -i compiled.qasm --backend iqm \
+    --scheduler slurm \
+    --partition q_fiqci \
+    --account project_462000xxx \
+    --time "00:30:00" \
+    --shots 1024
+```
+
+Track and collect:
+
+```bash
+arvak status <job-id>            # single job
+arvak status --all               # everything you submitted
+arvak wait <job-id>              # block until terminal state
+arvak result <job-id> --format json > results.json
+```
+
+`--wait` on `submit` combines submit + wait. `--scheduler pbs` targets
+PBS/Torque; `--priority low|default|high|critical` sets queue priority.
+
+## Site notes
 
 ### LUMI (CSC, Finland)
 
-LUMI hosts IQM's Helmi quantum computer (5 qubits).
+IQM QPU behind the `q_fiqci` SLURM partition:
 
-**Configuration:**
-```yaml
-# ~/.arvak/config.yaml
-site: lumi
-scheduler:
-  type: slurm
-  partition: q_fiqci
-  account: project_462000xxx
-
-backend:
-  type: iqm
-  endpoint: https://qpu.lumi.csc.fi
-  auth_method: oidc
-  oidc_provider: https://auth.csc.fi
-
-defaults:
-  walltime: "00:30:00"
-  shots: 1024
-```
-
-**Module Setup:**
 ```bash
-# Load Arvak module (if installed system-wide)
-module load arvak
-
-# Or use local installation
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-**Authentication:**
-```bash
-# OIDC authentication via CSC
-arvak auth login --provider csc
-
-# Or set token directly
-export IQM_TOKEN="your-token-here"
+arvak auth login --provider csc --project project_462000xxx
+arvak submit -i circuit.qasm --backend iqm \
+    --scheduler slurm --partition q_fiqci \
+    --account project_462000xxx --time "00:15:00" --wait
 ```
 
 ### LRZ (Germany)
 
-LRZ hosts IQM quantum systems.
+Same workflow with `--provider lrz` and your local partition/account
+names. Ask your HPC support desk for the quantum partition name.
 
-**Configuration:**
-```yaml
-# ~/.arvak/config.yaml
-site: lrz
-scheduler:
-  type: slurm
-  partition: quantum
-  account: your-project
+## Programmatic use (Rust)
 
-backend:
-  type: iqm
-  endpoint: https://qpu.lrz.de
-  auth_method: oidc
-  oidc_provider: https://auth.lrz.de
-```
-
-### Generic HPC Site
-
-For sites without pre-configured profiles:
-
-```yaml
-# ~/.arvak/config.yaml
-site: custom
-scheduler:
-  type: slurm
-  partition: default
-  account: myaccount
-
-backend:
-  type: ibm
-  endpoint: https://api.quantum-computing.ibm.com
-  token: ${IBM_QUANTUM_TOKEN}
-```
-
-## Installation on HPC Systems
-
-### Method 1: Pre-built Binary
-
-```bash
-# Download release binary
-curl -LO https://github.com/arvak-project/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
-
-# Extract
-tar xzf arvak-linux-x86_64.tar.gz
-
-# Install to user directory
-mkdir -p ~/.local/bin
-mv arvak arvak-runner ~/.local/bin/
-
-# Add to PATH
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-```
-
-### Method 2: Build from Source
-
-```bash
-# Load build dependencies (site-specific)
-module load rust/1.83
-
-# Clone and build
-git clone https://github.com/arvak-project/arvak
-cd arvak
-cargo build --release
-
-# Install
-cp target/release/arvak target/release/arvak-runner ~/.local/bin/
-```
-
-### Method 3: Environment Module
-
-For system-wide installation, create a module file:
-
-```lua
--- /opt/modulefiles/arvak/0.1.0.lua
-whatis("Arvak: Rust-native quantum compilation stack")
-
-local base = "/opt/arvak/0.1.0"
-
-prepend_path("PATH", pathJoin(base, "bin"))
-prepend_path("LD_LIBRARY_PATH", pathJoin(base, "lib"))
-
--- Load dependencies
-depends_on("iqm-client")
-```
-
-## Usage Examples
-
-### Basic Submission
-
-```bash
-# Submit a quantum job
-arvak submit -i circuit.qasm \
-    --backend iqm \
-    --shots 1024 \
-    --scheduler slurm \
-    --partition q_fiqci \
-    --account project_462000xxx \
-    --time 00:30:00
-
-# Output: Job submitted: arvak-12345 (Slurm job: 98765)
-```
-
-### Check Status
-
-```bash
-# Arvak job status
-arvak status arvak-12345
-
-# Or directly via Slurm
-squeue -j 98765
-```
-
-### Retrieve Results
-
-```bash
-# Get results
-arvak result arvak-12345 --format json > results.json
-
-# Or as table
-arvak result arvak-12345 --format table
-```
-
-### Batch Submission
-
-```bash
-# Submit multiple circuits
-for circuit in circuits/*.qasm; do
-    arvak submit -i "$circuit" --backend iqm --shots 1024
-done
-```
-
-### Interactive Mode (Not Recommended)
-
-For debugging only:
-
-```bash
-# Request interactive session
-salloc --partition=q_fiqci --account=project_xxx --time=00:15:00
-
-# Run directly
-arvak run -i circuit.qasm --backend iqm --shots 100
-```
-
-## Job Workflow
-
-### 1. Local Compilation
-
-Compile circuit before submission to catch errors early.
-
-```bash
-# Compile for target
-arvak compile -i circuit.qasm -o compiled.qasm --target iqm
-
-# Verify
-arvak validate compiled.qasm --backend iqm
-```
-
-### 2. Submit to Scheduler
-
-```bash
-arvak submit -i compiled.qasm \
-    --backend iqm \
-    --shots 1024 \
-    --scheduler slurm
-```
-
-### 3. Job Execution
-
-The scheduler runs `arvak-runner` on a compute node:
-
-```
-arvak-runner workflow:
-1. Load job specification
-2. Connect to quantum backend
-3. Submit circuit
-4. Poll for completion
-5. Store results
-6. Exit
-```
-
-### 4. Result Retrieval
-
-```bash
-# Wait for completion
-arvak wait arvak-12345
-
-# Get results
-arvak result arvak-12345
-```
-
-## Advanced Configuration
-
-### Resource Limits
-
-```yaml
-# ~/.arvak/config.yaml
-limits:
-  max_shots: 100000
-  max_circuits_per_job: 100
-  max_walltime: "02:00:00"
-  max_concurrent_jobs: 10
-```
-
-### Retry Policy
-
-```yaml
-# ~/.arvak/config.yaml
-retry:
-  max_attempts: 3
-  backoff_base: 5  # seconds
-  backoff_max: 300  # seconds
-```
-
-### Offline Mode
-
-For air-gapped compute nodes:
-
-```yaml
-# ~/.arvak/config.yaml
-offline:
-  enabled: true
-  cache_dir: /scratch/arvak-cache
-  sync_interval: 300  # seconds
-```
+The `arvak-sched` crate exposes the same functionality as a library —
+scheduler configuration, batch/array jobs, persistence (JSON/SQLite),
+and resource matching. See the crate docs
+([`crates/arvak-sched`](../crates/arvak-sched)) for the API; the CLI
+above is a thin wrapper over it.
 
 ## Troubleshooting
 
-### Common Issues
+| Symptom | Check |
+|---------|-------|
+| `Authentication failed` | `arvak auth status`; token env var set and unexpired? |
+| `Invalid partition` | `sinfo -a` — partition names are site-specific |
+| Job pending forever | `squeue -u $USER`; QPU partitions often have narrow time windows |
+| Job exceeded walltime | Raise `--time`, or compile with a higher `--optimization-level` to shrink the circuit |
 
-**1. Authentication Failure**
-```
-Error: OIDC authentication failed
-```
-Solution: Refresh your authentication token:
-```bash
-arvak auth login --provider csc
-```
-
-**2. Partition Not Found**
-```
-Error: Invalid partition: q_fiqci
-```
-Solution: Check available partitions:
-```bash
-sinfo -a
-```
-
-**3. Backend Unavailable**
-```
-Error: Backend not available: iqm-lumi
-```
-Solution: Check backend status:
-```bash
-arvak backends --status
-```
-
-**4. Job Timeout**
-```
-Error: Job exceeded walltime
-```
-Solution: Increase walltime or reduce circuit complexity:
-```bash
-arvak submit -i circuit.qasm --time 01:00:00
-```
-
-### Debug Mode
+Verbose logging for bug reports:
 
 ```bash
-# Enable verbose logging
-arvak -vvv submit -i circuit.qasm --backend iqm
-
-# Check job logs
-cat arvak_98765.out
-cat arvak_98765.err
+arvak -vvv submit -i circuit.qasm --backend iqm ...
 ```
 
-### Support Channels
+## Security
 
-- HPC center support desk
-- Arvak GitHub issues
-- IQM/IBM support (for backend issues)
-
-## Security Considerations
-
-1. **Credential Storage** — Never store tokens in job scripts
-2. **File Permissions** — Protect config files: `chmod 600 ~/.arvak/config.yaml`
-3. **Shared Filesystems** — Be cautious with results on shared storage
-4. **OIDC Tokens** — Use short-lived tokens when possible
-
-## Performance Tips
-
-1. **Compile Locally** — Compile circuits before submission to reduce node time
-2. **Batch Jobs** — Submit multiple circuits in one job where possible
-3. **Result Streaming** — Use callbacks for large result sets
-4. **Partition Selection** — Use appropriate partition for job size
-5. **Off-Peak Hours** — Queue times are shorter during off-peak hours
+- Tokens only via environment variables or OIDC — never in job scripts
+  or shared filesystems.
+- Result files land in the submission directory; mind permissions on
+  shared storage.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,0 +1,162 @@
+# Python API Reference
+
+The `arvak` package is a thin PyO3 layer over the Rust core. This page
+covers the stable, user-facing surface. Docstrings (`help(arvak.compile)`)
+carry the full parameter details.
+
+> Every Python snippet on this page is executed by CI
+> (`crates/arvak-python/tests/test_doc_snippets.py`).
+
+## Circuits
+
+`Circuit(name, num_qubits=0)` builds circuits with a chainable gate API.
+Gate methods take parameters first, qubit indices last.
+
+```python
+import arvak
+
+qc = arvak.Circuit("demo", num_qubits=3)
+qc.h(0).cx(0, 1)                 # single- and two-qubit gates chain
+qc.rz(0.5, 2)                    # parameters first: rz(theta, qubit)
+qc.u(0.1, 0.2, 0.3, 0)           # u(theta, phi, lam, qubit)
+qc.prx(0.5, 0.25, 1)             # IQM native phased-RX: prx(theta, phi, qubit)
+qc.ccx(0, 1, 2)
+qc.measure_all()
+
+assert qc.num_qubits == 3        # property
+assert qc.depth() > 0            # method
+```
+
+Available gates: `x y z h s sdg t tdg sx p rx ry rz u prx` (single-qubit),
+`cx cy cz ch cp crz swap iswap` (two-qubit), `ccx cswap` (three-qubit),
+plus `barrier_all`, `reset`, `delay`, `measure(qubit, clbit)`,
+`measure_all`. Classical bits are added implicitly by `measure_all` or
+explicitly via `add_clbit()`.
+
+Prebuilt circuits: `Circuit.bell()`, `Circuit.ghz(n)`, `Circuit.qft(n)`.
+
+## Simulation
+
+`run_sim(circuit, shots)` runs the built-in statevector simulator
+(≤ 20 qubits, no network) and returns a `{bitstring: count}` dict:
+
+```python
+import arvak
+
+counts = arvak.run_sim(arvak.Circuit.bell(), shots=1000)
+assert set(counts) == {"00", "11"}
+```
+
+## Compilation
+
+`compile(circuit, coupling_map=None, basis_gates=None, optimization_level=1)`
+runs the full pipeline: layout, SWAP routing, basis translation, gate
+optimization. Gates outside the target basis are decomposed automatically.
+
+| Level | Layout | Routing |
+|-------|--------------|---------------------------|
+| 0 | trivial | greedy shortest-path SWAPs |
+| 1 | trivial | SABRE (default) |
+| 2–3 | dense region | SABRE + more optimization |
+
+```python
+import arvak
+
+qc = arvak.Circuit("toffoli", num_qubits=3)
+qc.ccx(0, 1, 2)
+
+compiled = arvak.compile(
+    qc,
+    coupling_map=arvak.CouplingMap.linear(5),
+    basis_gates=arvak.BasisGates.iqm(),
+    optimization_level=2,
+)
+# After routing the circuit spans the whole device.
+assert compiled.num_qubits == 5
+```
+
+**`CouplingMap`** — device connectivity. Constructors: `linear(n)`,
+`star(n)`, `full(n)`, `from_edge_list(n, edges)`, or `CouplingMap(n)` plus
+`add_edge(a, b)` calls.
+
+**`BasisGates`** — target native gate sets: `ibm()` (rz/sx/x/cx),
+`iqm()` (prx/cz), `heron()`, `universal()`, or any custom set via the
+constructor. `gates()` and `contains(name)` inspect a set.
+
+## Backends
+
+One entry point for all eleven vendors — the HAL contract makes them
+interchangeable:
+
+```python
+import arvak
+
+print(arvak.list_backends())     # names + availability
+```
+
+```python
+# doc-test: skip  (hardware backends need vendor credentials)
+import arvak
+
+backend = arvak.backend_for("iqm_garnet")
+result = backend.run(qasm_string, shots=1024)
+print(result.counts)
+```
+
+`backend.run()` takes an OpenQASM 3 string. Vendor adapters handle
+authentication, submission, polling, and result decoding.
+
+## QASM 3 I/O
+
+`to_qasm(circuit)` emits standalone-valid OpenQASM 3 (includes
+`stdgates.inc`, defines non-standard gates like `prx` inline, uses
+`dt`-unit delays). `from_qasm(source)` parses it back — including
+Qiskit's QASM 3 exports.
+
+```python
+import arvak
+
+qasm = arvak.to_qasm(arvak.Circuit.bell())
+assert 'include "stdgates.inc";' in qasm
+
+roundtrip = arvak.from_qasm(qasm)
+assert roundtrip.num_qubits == 2
+```
+
+## Framework integrations
+
+Installed extras register automatically:
+
+```python
+import arvak
+
+print(arvak.list_integrations())   # e.g. {'qiskit': True}
+```
+
+With `pip install arvak[qiskit]`, Arvak acts as a Qiskit provider, and
+circuits convert in both directions:
+
+```python
+# doc-test: skip  (requires the qiskit extra)
+from qiskit import QuantumCircuit
+from arvak.integrations.qiskit import ArvakProvider
+
+qc = QuantumCircuit(2, 2)
+qc.h(0); qc.cx(0, 1); qc.measure_all()
+
+backend = ArvakProvider().get_backend("sim")
+print(backend.run(qc, shots=1000).result().get_counts())
+
+# Direct conversion without the provider:
+import arvak
+arvak_qc = arvak.get_integration("qiskit").to_arvak(qc)
+```
+
+Qrisp, Cirq, and PennyLane integrations follow the same pattern; see
+[INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md).
+
+## Optional modules
+
+- `arvak.nathan` — literature-grounded circuit analysis
+  (`pip install arvak[nathan]`)
+- `arvak.optimize` — VQE/QAOA workflows (see module docstrings)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,282 +1,129 @@
-# Arvak Quick Start Guide
+# Quick Start
 
-## Installation
+Arvak is a Rust-native quantum compilation platform with Python bindings,
+a CLI, and adapters for eleven hardware backends.
 
-### From Pre-built Binary (Recommended)
+> Every Python snippet on this page is executed by CI
+> (`crates/arvak-python/tests/test_doc_snippets.py`). If you can read it,
+> it runs against the current code.
+
+## Install
 
 ```bash
-# Download latest release
-curl -LO https://github.com/arvak-project/arvak/releases/latest/download/arvak-linux-x86_64.tar.gz
+# Python API (recommended)
+pip install arvak
 
-# Extract
-tar xzf arvak-linux-x86_64.tar.gz
-
-# Move to PATH
-sudo mv arvak arvak-runner /usr/local/bin/
-
-# Verify installation
-arvak --version
+# With framework integrations
+pip install arvak[qiskit]      # also: arvak[qrisp], arvak[cirq], arvak[pennylane]
 ```
 
-### From Source
+Building the CLI from source requires the `hal-contract` sibling checkout
+(it is a workspace path dependency):
 
 ```bash
-# Prerequisites: Rust 1.83+
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Clone and build
-git clone https://github.com/arvak-project/arvak
-cd arvak
-cargo build --release
-
-# Install
+git clone https://github.com/hiq-lab/arvak
+git clone https://github.com/hiq-lab/hal-contract
+cd arvak && ln -s ../hal-contract .hal-contract
 cargo install --path crates/arvak-cli
 ```
 
-### Python Bindings
+## First circuit (Python)
 
-```bash
-pip install arvak-python
+```python
+import arvak
+
+# Build a Bell state
+circuit = arvak.Circuit("bell", num_qubits=2)
+circuit.h(0).cx(0, 1).measure_all()
+
+# Run on the built-in statevector simulator (no network, no backend setup)
+counts = arvak.run_sim(circuit, shots=1000)
+print(counts)  # e.g. {'00': 498, '11': 502}
+
+# Compile for IQM hardware (native prx/cz gate set)
+compiled = arvak.compile(
+    circuit,
+    basis_gates=arvak.BasisGates.iqm(),
+    optimization_level=2,
+)
+print(compiled.depth())
 ```
 
-## Your First Circuit
+See [python-api.md](python-api.md) for the full API surface.
 
-### Using the CLI
+## First circuit (CLI)
 
-Create a file `bell.qasm`:
+Create `bell.qasm`:
 
 ```qasm
 OPENQASM 3.0;
+include "stdgates.inc";
 qubit[2] q;
 bit[2] c;
-
 h q[0];
 cx q[0], q[1];
-
-c = measure q;
+c[0] = measure q[0];
+c[1] = measure q[1];
 ```
-
-Compile and run:
 
 ```bash
-# Compile for IQM
-arvak compile -i bell.qasm -o bell_compiled.qasm --target iqm
-
-# Run on simulator
-arvak run -i bell_compiled.qasm --backend simulator --shots 1000
-
-# Output:
-# Results (1000 shots):
-#   00: 498 (49.80%)
-#   11: 502 (50.20%)
+arvak run -i bell.qasm --shots 1024          # run on the local simulator
+arvak backends                               # list available backends
+arvak compile -i bell.qasm --target iqm \
+    --optimization-level 2 -o compiled.qasm  # compile for hardware
 ```
 
-### Using the Rust API
+See [cli.md](cli.md) for all commands and flags.
+
+## First circuit (Rust)
 
 ```rust
 use arvak_ir::Circuit;
-use arvak_compile::{PassManagerBuilder, PropertySet, CouplingMap, BasisGates};
 use arvak_hal::Backend;
 use arvak_adapter_sim::SimulatorBackend;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Create Bell state circuit
     let circuit = Circuit::bell()?;
-    println!("Created circuit with {} qubits", circuit.num_qubits());
 
-    // Setup compilation for IQM
-    let properties = PropertySet::new()
-        .with_target(
-            CouplingMap::star(5),
-            BasisGates::iqm(),
-        );
-
-    let (pm, mut props) = PassManagerBuilder::new()
-        .with_optimization_level(2)
-        .with_properties(properties)
-        .build();
-
-    // Compile
-    let mut dag = circuit.clone().into_dag();
-    pm.run(&mut dag, &mut props)?;
-    let compiled = Circuit::from_dag(dag);
-    println!("Compiled circuit depth: {}", compiled.depth());
-
-    // Run on simulator
     let backend = SimulatorBackend::new();
-    let job_id = backend.submit(&compiled, 1000).await?;
+    let job_id = backend.submit(&circuit, 1000, None).await?;
     let result = backend.wait(&job_id).await?;
 
-    // Print results
-    println!("\nResults ({} shots):", result.shots);
-    for (bitstring, count) in result.counts.iter() {
-        let prob = *count as f64 / result.shots as f64;
-        println!("  {}: {} ({:.2}%)", bitstring, count, prob * 100.0);
-    }
-
+    println!("Results: {:?}", result.counts);
     Ok(())
 }
 ```
 
-### Using the Python API
+## Submitting to real hardware
+
+Hardware access needs vendor credentials (environment variables, see the
+adapter READMEs under [`adapters/`](../adapters)). The workflow is the same
+for every vendor:
 
 ```python
-from arvak import Circuit, compile_for_backend, SimulatorBackend
+# doc-test: skip  (needs vendor credentials)
+import arvak
 
-# Create Bell state circuit
-circuit = Circuit.bell()
-print(f"Created circuit with {circuit.num_qubits()} qubits")
-
-# Compile for IQM
-compiled = compile_for_backend(circuit, "iqm", optimization_level=2)
-print(f"Compiled circuit depth: {compiled.depth()}")
-
-# Run on simulator
-backend = SimulatorBackend()
-result = backend.run(compiled, shots=1000)
-
-# Print results
-print(f"\nResults ({result.shots} shots):")
-for bitstring, count in result.counts.items():
-    prob = count / result.shots * 100
-    print(f"  {bitstring}: {count} ({prob:.2f}%)")
+backend = arvak.backend_for("iqm_garnet")   # or "ibm_marrakesh", "sim", ...
+result = backend.run(qasm_string, shots=1024)
+print(result.counts)
 ```
 
-## Common Operations
-
-### Create Custom Circuits
-
-```rust
-use arvak_ir::{Circuit, QubitId};
-use std::f64::consts::PI;
-
-let mut circuit = Circuit::new("my_circuit");
-
-// Add qubits and classical bits
-let q = circuit.add_qreg("q", 3);
-let c = circuit.add_creg("c", 3);
-
-// Apply gates
-circuit
-    .h(q[0])?
-    .cx(q[0], q[1])?
-    .cx(q[1], q[2])?
-    .rz(PI / 4.0, q[2])?
-    .measure(q[0], c[0])?
-    .measure(q[1], c[1])?
-    .measure(q[2], c[2])?;
-```
-
-### Compile for Different Backends
-
-```rust
-// For IQM (PRX + CZ basis)
-let iqm_props = PropertySet::new()
-    .with_target(CouplingMap::star(5), BasisGates::iqm());
-
-// For IBM (RZ + SX + X + CX basis)
-let ibm_props = PropertySet::new()
-    .with_target(CouplingMap::linear(5), BasisGates::ibm());
-```
-
-### Submit to Real Hardware
+Via the CLI, including HPC batch schedulers:
 
 ```bash
-# Set credentials
-export IQM_TOKEN="your-token-here"
-
-# Submit to IQM Resonance
-arvak submit -i circuit.qasm \
-    --backend iqm \
-    --shots 1024 \
-    --wait
-
-# Check status
-arvak status <job-id> --backend iqm
-
-# Get results
-arvak result <job-id> --backend iqm --format json
+arvak auth login --provider csc --project project_462000xxx
+arvak submit -i circuit.qasm --backend iqm \
+    --scheduler slurm --partition q_fiqci \
+    --account project_462000xxx --time "00:30:00" --wait
 ```
 
-### HPC Scheduler Integration
+See [hpc-deployment.md](hpc-deployment.md) for LUMI/LRZ specifics.
 
-```bash
-# Submit via Slurm
-arvak submit -i circuit.qasm \
-    --backend iqm \
-    --shots 1024 \
-    --scheduler slurm \
-    --partition quantum \
-    --account my-project \
-    --time 00:30:00
-```
+## Next steps
 
-## Configuration
-
-### Config File
-
-Create `~/.arvak/config.yaml`:
-
-```yaml
-# Default backend
-default_backend: simulator
-
-# Backend configurations
-backends:
-  simulator:
-    type: simulator
-
-  iqm:
-    type: iqm
-    endpoint: https://cocos.resonance.meetiqm.com
-    token: ${IQM_TOKEN}
-
-  ibm:
-    type: ibm
-    token: ${IBM_QUANTUM_TOKEN}
-
-# Scheduler configuration
-scheduler:
-  type: slurm
-  partition: quantum
-  account: my-project
-
-# Compilation defaults
-compilation:
-  optimization_level: 2
-  target: iqm
-```
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `IQM_TOKEN` | IQM Resonance API token |
-| `IBM_QUANTUM_TOKEN` | IBM Quantum API token |
-| `ARVAK_CONFIG` | Custom config file path |
-| `ARVAK_LOG` | Log level (error, warn, info, debug, trace) |
-
-## Next Steps
-
-- [Architecture Overview](architecture.md) — Understand the system design
-- [IR Specification](ir-specification.md) — Learn the circuit representation
-- [Compilation Guide](compilation.md) — Explore transpilation passes
-- [HPC Deployment](hpc-deployment.md) — Deploy on HPC clusters
-- [Contributing](../CONTRIBUTING.md) — Join the development
-
-## Getting Help
-
-```bash
-# CLI help
-arvak --help
-arvak compile --help
-arvak submit --help
-
-# Verbose output for debugging
-arvak -vvv submit -i circuit.qasm --backend iqm
-```
-
-For issues and questions:
-- GitHub Issues: https://github.com/arvak-project/arvak/issues
-- Documentation: https://arvak-project.github.io/arvak/
+- [Python API reference](python-api.md)
+- [CLI reference](cli.md)
+- [Compilation pipeline](compilation.md) — passes, optimization levels
+- [Architecture](architecture.md) — crate layout, HAL design

--- a/scripts/gen-cli-docs.sh
+++ b/scripts/gen-cli-docs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Regenerate docs/cli.md from the CLI's own --help output.
+# Run after changing arvak-cli commands or flags:
+#   ./scripts/gen-cli-docs.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+cargo build -p arvak-cli --quiet
+BIN=target/debug/arvak
+OUT=docs/cli.md
+
+{
+  echo "# CLI Reference"
+  echo
+  echo "> Generated from \`arvak --help\` by [\`scripts/gen-cli-docs.sh\`](../scripts/gen-cli-docs.sh)."
+  echo "> Do not edit by hand — rerun the script after CLI changes."
+  echo
+  echo '```text'
+  "$BIN" --help
+  echo '```'
+  for cmd in compile run submit status result auth wait eval backends; do
+    echo
+    echo "## arvak $cmd"
+    echo
+    echo '```text'
+    "$BIN" "$cmd" --help
+    echo '```'
+  done
+} > "$OUT"
+
+echo "wrote $OUT"


### PR DESCRIPTION
## Summary

Closes the last structural item from the IQM reviewer feedback: "no systematic documentation beyond scattered code snippets; correct interface usage only discoverable by reading the source."

### What's new

| File | Role |
|------|------|
| `docs/README.md` | Audience-oriented index (using / extending / internals) + maintenance policy |
| `docs/quickstart.md` | Rewritten — install, first circuit in Python / CLI / Rust, hardware + HPC submission. The old version invented APIs (`compile_for_backend`, a Python `SimulatorBackend`, `~/.arvak/config.yaml`) and was the seed of the broken landing-page snippets. |
| `docs/python-api.md` | New — the real user-facing Python surface: `Circuit`, `run_sim`, `compile`, `CouplingMap`/`BasisGates`, backends, QASM 3 I/O, integrations |
| `docs/cli.md` | Generated from `arvak --help` by `scripts/gen-cli-docs.sh` — never hand-edited |

### How it stays correct (the actual point of this PR)

- **Every ` ```python ` block in `quickstart.md` and `python-api.md` is executed in CI** by `crates/arvak-python/tests/test_doc_snippets.py`, now wired into the Python Bindings job against the freshly built wheel. Snippets that need credentials or optional extras carry a `# doc-test: skip` marker with the reason. Documentation drift of the kind the reviewer hit now fails CI.
- The CLI reference is regenerated, not maintained: `./scripts/gen-cli-docs.sh`.
- Prose stays thin by policy (documented in the index): behavior, defaults, and intent — not signatures that docstrings already carry.

### Verification

- `pytest crates/arvak-python/tests/test_doc_snippets.py -v`: 7 passed, 3 skipped (2× vendor credentials, 1× qiskit extra) — all snippet assertions (register sizes after routing, stdgates include, Bell counts) hold against the current bindings
- `docs/cli.md` generated from the current binary
- arvak.io navigation now links "Docs" → `docs/README.md` (deployed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)