### PR TITLE
fix(qasm3): report the offending token's line in parse errors

### DIFF
--- a/crates/arvak-qasm3/src/parser/expression.rs
+++ b/crates/arvak-qasm3/src/parser/expression.rs
@@ -129,7 +129,7 @@ impl Parser {
                 Ok(Expression::Paren(Box::new(expr)))
             }
             _ => Err(ParseError::UnexpectedToken {
-                line: self.line,
+                line: self.peek_line(),
                 expected: "expression".into(),
                 found: token.to_string(),
             }),

--- a/crates/arvak-qasm3/src/parser/mod.rs
+++ b/crates/arvak-qasm3/src/parser/mod.rs
@@ -35,8 +35,8 @@ pub(super) const MAX_EXPR_DEPTH: usize = 256;
 pub(super) struct Parser {
     pub(super) tokens: Vec<SpannedToken>,
     pub(super) pos: usize,
-    // TODO: Track line numbers by incrementing on newline tokens
-    pub(super) line: usize,
+    /// Byte offset of every `\n` in the source, for span → line lookup.
+    newline_offsets: Vec<usize>,
     /// Current expression recursion depth (guarded by `MAX_EXPR_DEPTH`).
     pub(super) expr_depth: usize,
 }
@@ -66,12 +66,40 @@ impl Parser {
             }
         }
 
+        let newline_offsets = source
+            .bytes()
+            .enumerate()
+            .filter_map(|(i, b)| (b == b'\n').then_some(i))
+            .collect();
+
         Ok(Self {
             tokens,
             pos: 0,
-            line: 1,
+            newline_offsets,
             expr_depth: 0,
         })
+    }
+
+    /// 1-based line number of a byte offset in the source.
+    fn line_of_offset(&self, offset: usize) -> usize {
+        self.newline_offsets.partition_point(|&nl| nl < offset) + 1
+    }
+
+    /// Line of the most recently consumed token — use for errors raised
+    /// after `advance()`/`expect()`.
+    pub(super) fn line(&self) -> usize {
+        let last = self.tokens.len().saturating_sub(1);
+        self.tokens
+            .get(self.pos.saturating_sub(1).min(last))
+            .map_or(1, |t| self.line_of_offset(t.span.start))
+    }
+
+    /// Line of the next (peeked) token — use for errors raised before
+    /// consuming it.
+    pub(super) fn peek_line(&self) -> usize {
+        self.tokens
+            .get(self.pos)
+            .map_or_else(|| self.line(), |t| self.line_of_offset(t.span.start))
     }
 
     /// Check if we've reached the end.
@@ -103,7 +131,7 @@ impl Parser {
 
         if std::mem::discriminant(&found) != std::mem::discriminant(&expected) {
             return Err(ParseError::UnexpectedToken {
-                line: self.line,
+                line: self.line(),
                 expected: expected.to_string(),
                 found: found.to_string(),
             });
@@ -170,7 +198,7 @@ impl Parser {
         match self.advance() {
             Some(Token::Identifier(s)) => Ok(s),
             Some(other) => Err(ParseError::UnexpectedToken {
-                line: self.line,
+                line: self.line(),
                 expected: "identifier".into(),
                 found: other.to_string(),
             }),
@@ -183,7 +211,7 @@ impl Parser {
         match self.advance() {
             Some(Token::IntLiteral(v)) => Ok(v),
             Some(other) => Err(ParseError::UnexpectedToken {
-                line: self.line,
+                line: self.line(),
                 expected: "integer".into(),
                 found: other.to_string(),
             }),
@@ -195,6 +223,33 @@ impl Parser {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Parse errors must report the line of the offending token, not
+    /// always "line 1" (IQM reviewer feedback: the constant line number
+    /// made errors in longer programs impossible to locate).
+    #[test]
+    fn test_error_reports_correct_line_for_unexpected_statement() {
+        // `)` on line 4 cannot start a statement.
+        let source = "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n) q[0];\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("line 4"), "expected line 4 in: {err}");
+    }
+
+    #[test]
+    fn test_error_reports_correct_line_for_failed_expect() {
+        // Missing `]` on line 3.
+        let source = "OPENQASM 3.0;\nqubit[2] q;\nbit[2 c;\nh q[0];\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("line 3"), "expected line 3 in: {err}");
+    }
+
+    #[test]
+    fn test_error_reports_correct_line_for_bad_expression() {
+        // `;` where an expression is required, on line 5.
+        let source = "OPENQASM 3.0;\nqubit[1] q;\nh q[0];\nx q[0];\nrz(;) q[0];\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("line 5"), "expected line 5 in: {err}");
+    }
 
     #[test]
     fn test_parse_bell_state() {

--- a/crates/arvak-qasm3/src/parser/statement.rs
+++ b/crates/arvak-qasm3/src/parser/statement.rs
@@ -35,7 +35,7 @@ impl Parser {
             }
             Token::Identifier(_) => self.parse_identifier_statement(),
             _ => Err(ParseError::UnexpectedToken {
-                line: self.line,
+                line: self.peek_line(),
                 expected: "statement".into(),
                 found: token.to_string(),
             }),
@@ -69,7 +69,7 @@ impl Parser {
             Some(Token::StringLiteral(s)) => s,
             Some(other) => {
                 return Err(ParseError::UnexpectedToken {
-                    line: self.line,
+                    line: self.line(),
                     expected: "string literal".into(),
                     found: other.to_string(),
                 });


### PR DESCRIPTION
## Summary

Parse errors always reported `line 1`: the parser initialised `line: 1` and never updated it (the struct even carried a TODO). This was the last open item from the IQM reviewer feedback — his bug #2 error message pointed at "line 1" for a failure that was actually mid-file.

Line numbers are now computed from the lexer's token spans (which were already captured but unused) via a precomputed newline-offset table with binary search:

- `Parser::line()` — line of the most recently consumed token, for errors raised after `advance()`/`expect()`
- `Parser::peek_line()` — line of the next token, for errors raised on a peeked token (statement/expression dispatch)

## Verification

- Three new TDD tests assert the correct line for the three error paths (failed `expect`, unexpected statement token, bad expression) — all reported `line 1` before the fix
- Full workspace tests green; clippy clean with the nightly-CI flag set

🤖 Generated with [Claude Code](https://claude.com/claude-code)