### PR TITLE
test(compile): property-based pipeline fuzzing + three gaps it found

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,6 +214,12 @@ jobs:
         if: matrix.profile == 'release'
         run: cargo test --workspace --exclude arvak-python --release
 
+      # Extended property-based fuzzing of the compilation pipeline.
+      # PR CI runs the same test with 32 cases; nightly goes deep.
+      - name: Pipeline fuzzing (extended)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release'
+        run: PROPTEST_CASES=512 cargo test -p arvak-compile --release --test proptest_pipeline
+
       # Adapter feature-flag builds (ubuntu release only — folded from adapter-compat)
       - name: Build CLI with all backends
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release'

--- a/crates/arvak-compile/src/manager.rs
+++ b/crates/arvak-compile/src/manager.rs
@@ -125,6 +125,12 @@ impl PassManagerBuilder {
         let mut pm = PassManager::new();
 
         // Add layout pass if we have a coupling map.
+        // The routing passes only understand 1q/2q operations; expand
+        // anything wider (ccx, cswap) before layout/routing.
+        if self.properties.coupling_map.is_some() {
+            pm.add_pass(crate::passes::Unroll3q);
+        }
+
         // Level >= 2 uses DenseLayout (topology-aware placement),
         // otherwise TrivialLayout (identity mapping).
         if self.properties.coupling_map.is_some() {

--- a/crates/arvak-compile/src/passes/agnostic/mod.rs
+++ b/crates/arvak-compile/src/passes/agnostic/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod noise_injection;
 pub mod optimization;
+pub mod unroll_3q;
 pub mod verification;
 pub mod verify_compilation;
 
@@ -13,5 +14,6 @@ pub use noise_injection::NoiseInjectionPass;
 pub use optimization::{
     CancelCX, CommutativeCancellation, ConsolidateBlocks, OneQubitBasis, Optimize1qGates,
 };
+pub use unroll_3q::Unroll3q;
 pub use verification::{MeasurementBarrierVerification, VerificationResult};
 pub use verify_compilation::VerifyCompilation;

--- a/crates/arvak-compile/src/passes/agnostic/unroll_3q.rs
+++ b/crates/arvak-compile/src/passes/agnostic/unroll_3q.rs
@@ -1,0 +1,87 @@
+//! Decompose gates on three or more qubits before routing.
+//!
+//! The routing passes only understand one- and two-qubit operations:
+//! `BasicRouting` leaves wider gates on non-adjacent qubits and
+//! `SabreRouting` does not track them at all. Following the standard
+//! pipeline design (cf. Qiskit's `Unroll3qOrMore`), everything wider than
+//! two qubits is expanded into one- and two-qubit standard gates before
+//! layout/routing runs.
+//!
+//! Found by property-based fuzzing (2026-07-08): a bare `ccx` compiled at
+//! optimization level 0 produced CX gates on uncoupled qubit pairs.
+
+use arvak_ir::{CircuitDag, GateKind, InstructionKind};
+
+use crate::error::{CompileError, CompileResult};
+use crate::pass::{Pass, PassKind};
+use crate::passes::target::decompose_to_simpler;
+use crate::property::PropertySet;
+
+/// Expand >=3-qubit standard gates into 1q/2q gates.
+pub struct Unroll3q;
+
+impl Pass for Unroll3q {
+    fn name(&self) -> &'static str {
+        "Unroll3q"
+    }
+
+    fn kind(&self) -> PassKind {
+        PassKind::Transformation
+    }
+
+    fn run(&self, dag: &mut CircuitDag, _properties: &mut PropertySet) -> CompileResult<()> {
+        let needs_unroll = dag.topological_ops().any(|(_, inst)| {
+            matches!(&inst.kind, InstructionKind::Gate(_)) && inst.qubits.len() >= 3
+        });
+        if !needs_unroll {
+            return Ok(());
+        }
+
+        let mut new_dag = CircuitDag::new();
+        for q in dag.qubits().collect::<Vec<_>>() {
+            new_dag.add_qubit(q);
+        }
+        for c in dag.clbits().collect::<Vec<_>>() {
+            new_dag.add_clbit(c);
+        }
+
+        for (_, inst) in dag.topological_ops() {
+            let wide_standard = match &inst.kind {
+                InstructionKind::Gate(g) if inst.qubits.len() >= 3 => match &g.kind {
+                    GateKind::Standard(std_gate) => Some(std_gate.clone()),
+                    GateKind::Custom(_) => {
+                        return Err(CompileError::PassFailed {
+                            name: "Unroll3q".into(),
+                            reason: format!(
+                                "cannot decompose {}-qubit custom gate '{}' for routing",
+                                inst.qubits.len(),
+                                g.name()
+                            ),
+                        });
+                    }
+                },
+                _ => None,
+            };
+
+            if let Some(std_gate) = wide_standard {
+                let steps = decompose_to_simpler(&std_gate, &inst.qubits).ok_or_else(|| {
+                    CompileError::PassFailed {
+                        name: "Unroll3q".into(),
+                        reason: format!("no decomposition for wide gate '{std_gate:?}'"),
+                    }
+                })?;
+                for step in steps {
+                    debug_assert!(step.qubits.len() <= 2);
+                    new_dag.apply(step).map_err(CompileError::Ir)?;
+                }
+            } else {
+                new_dag.apply(inst.clone()).map_err(CompileError::Ir)?;
+            }
+        }
+
+        new_dag.set_global_phase(dag.global_phase());
+        new_dag.set_level(dag.level());
+        *dag = new_dag;
+        Ok(())
+    }
+}

--- a/crates/arvak-compile/src/passes/mod.rs
+++ b/crates/arvak-compile/src/passes/mod.rs
@@ -10,7 +10,7 @@ pub mod target;
 // Re-exports for backward compatibility
 pub use agnostic::{
     CancelCX, CommutativeCancellation, ConsolidateBlocks, MeasurementBarrierVerification,
-    OneQubitBasis, Optimize1qGates, VerificationResult, VerifyCompilation,
+    OneQubitBasis, Optimize1qGates, Unroll3q, VerificationResult, VerifyCompilation,
 };
 pub use target::{
     BasicRouting, BasisTranslation, DenseLayout, NeutralAtomRouting, SabreRouting, TrivialLayout,

--- a/crates/arvak-compile/src/passes/target/mod.rs
+++ b/crates/arvak-compile/src/passes/target/mod.rs
@@ -17,3 +17,4 @@ pub use neutral_atom_routing::{NeutralAtomRouting, ZoneAssignment};
 pub use routing::BasicRouting;
 pub use sabre_routing::SabreRouting;
 pub use translation::BasisTranslation;
+pub(crate) use translation::decompose_to_simpler;

--- a/crates/arvak-compile/src/passes/target/sabre_routing.rs
+++ b/crates/arvak-compile/src/passes/target/sabre_routing.rs
@@ -85,6 +85,21 @@ fn sabre_pass(
     let mut emitted: Vec<Instruction> = Vec::new();
     let mut swap_count: usize = 0;
 
+    // SABRE only tracks 1q and 2q operations; a wider gate would be
+    // silently dropped from the output. Fail loudly instead — the default
+    // pipeline runs Unroll3q before routing.
+    if let Some(wide) = ops.iter().find(|inst| {
+        matches!(&inst.kind, arvak_ir::InstructionKind::Gate(_)) && inst.qubits.len() >= 3
+    }) {
+        return Err(CompileError::PassFailed {
+            name: "SabreRouting".into(),
+            reason: format!(
+                "cannot route {}-qubit gate; run Unroll3q before routing",
+                wide.qubits.len()
+            ),
+        });
+    }
+
     // Build dependency graph: for each two-qubit gate, track which gates
     // must execute before it (on the same qubit).
     let num_ops = ops.len();

--- a/crates/arvak-compile/src/passes/target/translation.rs
+++ b/crates/arvak-compile/src/passes/target/translation.rs
@@ -184,7 +184,7 @@ fn translate_gate(
 ///
 /// All decompositions are exact up to global phase, which is unobservable.
 #[allow(clippy::too_many_lines)]
-fn decompose_to_simpler(
+pub(crate) fn decompose_to_simpler(
     gate: &StandardGate,
     qubits: &[arvak_ir::QubitId],
 ) -> Option<Vec<Instruction>> {
@@ -207,11 +207,15 @@ fn decompose_to_simpler(
             single(StandardGate::Rz(phi.clone()), q0),
         ],
 
-        // SXdg == S . H . S up to global phase.
-        StandardGate::SXdg => vec![
-            single(StandardGate::S, q0),
-            single(StandardGate::H, q0),
-            single(StandardGate::S, q0),
+        // SX == Rx(pi/2), SXdg == Rx(-pi/2), both up to global phase.
+        StandardGate::SX => vec![single(StandardGate::Rx(P::constant(PI / 2.0)), q0)],
+        StandardGate::SXdg => vec![single(StandardGate::Rx(P::constant(-PI / 2.0)), q0)],
+
+        // PRX(theta, phi) == Rz(phi) . Rx(theta) . Rz(-phi)  (exact).
+        StandardGate::PRX(theta, phi) => vec![
+            single(StandardGate::Rz(-phi.clone()), q0),
+            single(StandardGate::Rx(theta.clone()), q0),
+            single(StandardGate::Rz(phi.clone()), q0),
         ],
 
         StandardGate::CY => {

--- a/crates/arvak-compile/tests/proptest_pipeline.rs
+++ b/crates/arvak-compile/tests/proptest_pipeline.rs
@@ -1,0 +1,283 @@
+//! Property-based fuzzing of the full compilation pipeline.
+//!
+//! Random circuits (full standard-gate set, 2-10 qubits) are compiled on
+//! random connected coupling maps (spanning tree + extra edges, built via
+//! both `from_edge_list` and the `new()`+`add_edge()` path) for random
+//! bases and optimization levels. Every case must satisfy the same
+//! invariants as the corpus sweep in `pipeline_invariants.rs`:
+//!
+//! 1. the pipeline terminates and succeeds (a hang fails via job timeout)
+//! 2. the emitted QASM3 parses back
+//! 3. every gate is in the target basis
+//! 4. every 2-qubit gate acts on coupled physical qubits
+//! 5. register sizes are consistent
+//! 6. layout-aware statevector equivalence (circuits are <= 10 qubits)
+//!
+//! This is the only test genre that finds *unknown* failure classes like
+//! the 2026-07 SABRE oscillation — corpus tests only re-check known
+//! shapes. Case count: 32 by default (fast PR CI), overridden via
+//! `PROPTEST_CASES` in the nightly job (512). Failures are persisted by
+//! proptest under `proptest-regressions/` — commit those files.
+
+use arvak_compile::passes::VerifyCompilation;
+use arvak_compile::property::{BasisGates, CouplingMap};
+use arvak_compile::{Pass, PassManagerBuilder};
+use arvak_ir::{Circuit, InstructionKind, QubitId};
+use proptest::prelude::*;
+
+const SEMANTICS_TRIALS: usize = 4;
+
+/// One random gate: kind index, qubit picks, angles.
+#[derive(Debug, Clone)]
+struct GateSpec {
+    kind: usize,
+    q: [usize; 3],
+    theta: f64,
+    phi: f64,
+    lam: f64,
+}
+
+const NUM_GATE_KINDS: usize = 30;
+
+fn gate_strategy() -> impl Strategy<Value = GateSpec> {
+    (
+        0..NUM_GATE_KINDS,
+        prop::array::uniform3(0usize..64),
+        -3.1f64..3.1,
+        -3.1f64..3.1,
+        -3.1f64..3.1,
+    )
+        .prop_map(|(kind, q, theta, phi, lam)| GateSpec {
+            kind,
+            q,
+            theta,
+            phi,
+            lam,
+        })
+}
+
+/// Apply a gate spec to the circuit, mapping the raw qubit picks onto
+/// distinct in-range indices.
+#[allow(clippy::too_many_lines)]
+fn apply_gate(c: &mut Circuit, spec: &GateSpec, n: usize) {
+    let q0 = QubitId((spec.q[0] % n) as u32);
+    let q1 = QubitId(((spec.q[0] + 1 + spec.q[1] % (n - 1)) % n) as u32);
+    let q2_raw = (spec.q[0] + spec.q[2]) % n;
+    let (t, p, l) = (spec.theta, spec.phi, spec.lam);
+
+    // Ignore Result: builder errors here would be generator bugs, and the
+    // unwrap keeps failure output attached to the offending spec.
+    match spec.kind {
+        0 => c.x(q0).map(|_| ()).unwrap(),
+        1 => c.y(q0).map(|_| ()).unwrap(),
+        2 => c.z(q0).map(|_| ()).unwrap(),
+        3 => c.h(q0).map(|_| ()).unwrap(),
+        4 => c.s(q0).map(|_| ()).unwrap(),
+        5 => c.sdg(q0).map(|_| ()).unwrap(),
+        6 => c.t(q0).map(|_| ()).unwrap(),
+        7 => c.tdg(q0).map(|_| ()).unwrap(),
+        8 => c.sx(q0).map(|_| ()).unwrap(),
+        9 => c.sxdg(q0).map(|_| ()).unwrap(),
+        10 => c.rx(t, q0).map(|_| ()).unwrap(),
+        11 => c.ry(t, q0).map(|_| ()).unwrap(),
+        12 => c.rz(t, q0).map(|_| ()).unwrap(),
+        13 => c.p(t, q0).map(|_| ()).unwrap(),
+        14 => c.u(t, p, l, q0).map(|_| ()).unwrap(),
+        15 => c.prx(t, p, q0).map(|_| ()).unwrap(),
+        16 => c.cx(q0, q1).map(|_| ()).unwrap(),
+        17 => c.cy(q0, q1).map(|_| ()).unwrap(),
+        18 => c.cz(q0, q1).map(|_| ()).unwrap(),
+        19 => c.ch(q0, q1).map(|_| ()).unwrap(),
+        20 => c.cp(t, q0, q1).map(|_| ()).unwrap(),
+        21 => c.crx(t, q0, q1).map(|_| ()).unwrap(),
+        22 => c.cry(t, q0, q1).map(|_| ()).unwrap(),
+        23 => c.crz(t, q0, q1).map(|_| ()).unwrap(),
+        24 => c.swap(q0, q1).map(|_| ()).unwrap(),
+        25 => c.iswap(q0, q1).map(|_| ()).unwrap(),
+        26 => c.rxx(t, q0, q1).map(|_| ()).unwrap(),
+        27 => c.ryy(t, q0, q1).map(|_| ()).unwrap(),
+        28 => c.rzz(t, q0, q1).map(|_| ()).unwrap(),
+        29 => {
+            // Three-qubit gates need three distinct qubits.
+            if n < 3 {
+                c.ecr(q0, q1).map(|_| ()).unwrap();
+                return;
+            }
+            let mut q2 = QubitId(q2_raw as u32);
+            if q2 == q0 || q2 == q1 {
+                q2 = QubitId(((q1.0 as usize + 1 + usize::from(q2_raw != 0)) % n) as u32);
+            }
+            if q2 == q0 || q2 == q1 {
+                q2 = QubitId(((q0.0 as usize + n - 1) % n) as u32);
+            }
+            if q2 == q0 || q2 == q1 {
+                c.ecr(q0, q1).map(|_| ()).unwrap();
+            } else {
+                c.ccx(q0, q1, q2).map(|_| ()).unwrap();
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// A random connected coupling map over `device` qubits: random spanning
+/// tree plus a few extra edges, optionally built via the manual
+/// `new()`+`add_edge()` path (no precomputed distance matrices).
+#[derive(Debug, Clone)]
+struct MapSpec {
+    tree_parents: Vec<usize>,
+    extra_edges: Vec<(usize, usize)>,
+    manual: bool,
+}
+
+fn map_strategy() -> impl Strategy<Value = MapSpec> {
+    (
+        prop::collection::vec(0usize..1024, 1..12),
+        prop::collection::vec((0usize..64, 0usize..64), 0..4),
+        any::<bool>(),
+    )
+        .prop_map(|(tree_parents, extra_edges, manual)| MapSpec {
+            tree_parents,
+            extra_edges,
+            manual,
+        })
+}
+
+fn build_map(spec: &MapSpec, device: u32) -> CouplingMap {
+    let d = device as usize;
+    let mut edges: Vec<(u32, u32)> = Vec::new();
+    for i in 1..d {
+        let parent = spec.tree_parents[(i - 1) % spec.tree_parents.len()] % i;
+        edges.push((parent as u32, i as u32));
+    }
+    for &(a, b) in &spec.extra_edges {
+        let (a, b) = (a % d, b % d);
+        if a != b {
+            edges.push((a as u32, b as u32));
+        }
+    }
+    if spec.manual {
+        let mut map = CouplingMap::new(device);
+        for &(a, b) in &edges {
+            map.add_edge(a, b);
+        }
+        map
+    } else {
+        CouplingMap::from_edge_list(device, &edges)
+    }
+}
+
+const BASES: [fn() -> BasisGates; 5] = [
+    BasisGates::ibm,
+    BasisGates::eagle,
+    BasisGates::heron,
+    BasisGates::iqm,
+    BasisGates::neutral_atom,
+];
+
+fn fuzz_case(
+    n: usize,
+    gates: &[GateSpec],
+    map_spec: &MapSpec,
+    extra_qubits: u32,
+    basis_idx: usize,
+    level: u8,
+) {
+    let mut circuit = Circuit::with_size("fuzz", n as u32, 0);
+    for g in gates {
+        apply_gate(&mut circuit, g, n);
+    }
+
+    let device = n as u32 + extra_qubits;
+    let cmap = build_map(map_spec, device);
+    let basis = BASES[basis_idx % BASES.len()]();
+    let label = format!(
+        "n{n}+{extra_qubits} basis{basis_idx} o{level} manual:{}",
+        map_spec.manual
+    );
+
+    let mut dag = circuit.clone().into_dag();
+    let snapshot = VerifyCompilation::snapshot(&dag).with_num_trials(SEMANTICS_TRIALS);
+
+    // Invariant 1: pipeline succeeds.
+    let (pm, mut props) = PassManagerBuilder::new()
+        .with_optimization_level(level)
+        .with_target(cmap.clone(), basis.clone())
+        .build();
+    pm.run(&mut dag, &mut props)
+        .unwrap_or_else(|e| panic!("{label}: pipeline failed: {e}"));
+
+    // Invariant 5: register consistency.
+    let num_qubits = dag.num_qubits();
+    assert_eq!(
+        num_qubits, device as usize,
+        "{label}: routed circuit must span the device"
+    );
+    for (_, inst) in dag.topological_ops() {
+        for q in &inst.qubits {
+            assert!(
+                (q.0 as usize) < num_qubits,
+                "{label}: qubit index {} out of range",
+                q.0
+            );
+        }
+    }
+
+    // Invariants 3 + 4: basis conformance, coupling adjacency.
+    for (_, inst) in dag.topological_ops() {
+        if let InstructionKind::Gate(g) = &inst.kind {
+            assert!(
+                basis.contains(g.name()),
+                "{label}: non-basis gate '{}'",
+                g.name()
+            );
+            if inst.qubits.len() == 2 {
+                assert!(
+                    cmap.is_connected(inst.qubits[0].0, inst.qubits[1].0),
+                    "{label}: 2q gate on uncoupled qubits ({}, {})",
+                    inst.qubits[0].0,
+                    inst.qubits[1].0
+                );
+            }
+        }
+    }
+
+    // Invariant 2: emitted QASM3 re-parses.
+    let compiled = Circuit::from_dag(dag.clone());
+    let qasm = arvak_qasm3::emit(&compiled).unwrap_or_else(|e| panic!("{label}: emit failed: {e}"));
+    arvak_qasm3::parse(&qasm)
+        .unwrap_or_else(|e| panic!("{label}: emitted QASM does not re-parse: {e}\n{qasm}"));
+
+    // Invariant 6: statevector equivalence (layout-aware).
+    snapshot
+        .run(&mut dag, &mut props)
+        .unwrap_or_else(|e| panic!("{label}: NOT semantically equivalent: {e}"));
+}
+
+fn case_count() -> u32 {
+    std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(32)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: case_count(),
+        // Shrinking re-runs the full pipeline; keep it bounded.
+        max_shrink_iters: 200,
+        .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn fuzz_pipeline_invariants(
+        n in 2usize..=8,
+        gates in prop::collection::vec(gate_strategy(), 1..40),
+        map_spec in map_strategy(),
+        extra_qubits in 0u32..4,
+        basis_idx in 0usize..5,
+        level in 0u8..=3,
+    ) {
+        fuzz_case(n, &gates, &map_spec, extra_qubits, basis_idx, level);
+    }
+}

--- a/crates/arvak-compile/tests/unitary_equivalence.rs
+++ b/crates/arvak-compile/tests/unitary_equivalence.rs
@@ -212,6 +212,9 @@ fn test_decomposed_1q_gates_unitary_equivalent_all_bases() {
 
         let circuit = sandwich_1q(|c| c.sxdg(q).map(|_| ()).unwrap());
         assert_translation_preserves_semantics(&circuit, basis(), &format!("{name}/sxdg"));
+
+        let circuit = sandwich_1q(|c| c.prx(0.3, 0.7, q).map(|_| ()).unwrap());
+        assert_translation_preserves_semantics(&circuit, basis(), &format!("{name}/prx"));
     }
 }
 


### PR DESCRIPTION
## Summary

Suite 2 of the test-intensification plan: property-based fuzzing of the full compilation pipeline, plus fixes for the three gaps it found within minutes of its first run.

### The fuzzer

`tests/proptest_pipeline.rs` generates random circuits (full standard-gate set, 2–8 qubits, up to 40 gates) on random connected coupling maps (random spanning tree + extra edges, built via both `from_edge_list` and the manual `add_edge` path) for random bases × optimization levels 0–3. Each case must satisfy the same six invariants as the corpus sweep (`pipeline_invariants.rs`): termination, QASM3 re-parseability, basis conformance, coupling adjacency, register consistency, layout-aware statevector equivalence.

- PR CI: 32 cases (sub-second)
- Nightly (ubuntu release job): `PROPTEST_CASES=512`
- proptest persists failing seeds under `proptest-regressions/` for deterministic regression replay

### What it found

1. **3-qubit gates bypassed routing entirely.** `BasicRouting` left `ccx` operands on non-adjacent qubits; `SabreRouting` doesn't track >2q gates at all (they would be silently dropped). Fix: new `Unroll3q` pass (cf. Qiskit's `Unroll3qOrMore`) expands wide standard gates into 1q/2q gates before layout/routing; `SabreRouting` additionally fails loudly on >2q input.
2. **`sx`/`sxdg` had no generic decomposition** — translation to bases without sx (neutral_atom) failed with `Gate 'SX' not in target basis`. Added `SX == Rx(π/2)` / `SXdg == Rx(−π/2)` fallbacks.
3. **`prx` had no generic decomposition** — translation to any non-IQM basis failed. Added `PRX(θ, φ) == Rz(φ)·Rx(θ)·Rz(−φ)` (exact); `prx` is now part of the per-basis unitary-equivalence matrix.

## Verification

- 512-case release fuzz run passes in < 1 s
- Full workspace tests green (incl. the corpus invariant sweep and the 18-test unitary matrix, now with `prx`)
- Clippy clean with the nightly-CI flag set

🤖 Generated with [Claude Code](https://claude.com/claude-code)