### PR TITLE
ci: Python binding tests in PR CI + arvak-lite downstream compat in nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,13 +275,21 @@ jobs:
       - name: Build Python bindings
         run: cd crates/arvak-python && maturin build
 
-      - name: Test documentation snippets
-        # Executes every ```python block in docs/quickstart.md and
-        # docs/python-api.md against the freshly built bindings, so
-        # published examples can never drift from the real API again.
+      - name: Test Python bindings
+        # Core binding tests + qiskit integration + doc snippets against
+        # the freshly built wheel. Framework tests without their extra
+        # installed (qrisp/cirq/pennylane) skip; nathan needs heavy extras
+        # and is excluded here.
         run: |
-          pip install pytest target/wheels/*.whl
-          pytest crates/arvak-python/tests/test_doc_snippets.py -q
+          pip install pytest qiskit qiskit_qasm3_import target/wheels/*.whl
+          pytest -q \
+            crates/arvak-python/tests/test_circuit.py \
+            crates/arvak-python/tests/test_compile.py \
+            crates/arvak-python/tests/test_run_sim.py \
+            crates/arvak-python/tests/test_sim_bindings.py \
+            crates/arvak-python/tests/test_doc_snippets.py \
+            crates/arvak-python/tests/integrations \
+            --ignore=crates/arvak-python/tests/integrations/test_nathan.py
 
   security:
     name: Security Audit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -220,6 +220,39 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release'
         run: PROPTEST_CASES=512 cargo test -p arvak-compile --release --test proptest_pipeline
 
+      # Downstream compatibility: arvak-lite (separate PyPI package with an
+      # open `arvak>=x` dependency) must keep working against the wheel
+      # built from this commit. The 2.0 CouplingMap constructor change
+      # silently broke arvak-lite 0.1.1 in the wild — this catches the
+      # next such break before users do.
+      - name: Downstream compat (arvak-lite)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release'
+        run: |
+          pip install maturin
+          cd crates/arvak-python && maturin build --release --out ../../target/nightly-wheels
+          cd ../..
+          python -m venv /tmp/lite-compat
+          /tmp/lite-compat/bin/pip install "arvak-lite[qiskit]" qiskit_qasm3_import
+          /tmp/lite-compat/bin/pip install --force-reinstall --no-deps target/nightly-wheels/*.whl
+          /tmp/lite-compat/bin/python - <<'PY'
+          from qiskit import QuantumCircuit
+          from arvak_lite import transpile
+          import importlib.metadata as md
+          print("arvak", md.version("arvak"), "| arvak-lite", md.version("arvak-lite"))
+
+          qc = QuantumCircuit(3, 3)
+          qc.h(0); qc.ccx(0, 1, 2); qc.measure(range(3), range(3))
+          out = transpile(qc, coupling_map=[[0, 1], [1, 2]],
+                          basis_gates=["cx", "rz", "sx", "x"])
+          ops = out.count_ops()
+          assert "ccx" not in ops, f"ccx not decomposed: {ops}"
+          print("arvak-lite target path OK:", dict(ops))
+
+          from qiskit.compiler import transpile as qk
+          out2 = qk(qc, optimization_method="arvak")
+          print("qiskit plugin OK, depth", out2.depth())
+          PY
+
       # Adapter feature-flag builds (ubuntu release only — folded from adapter-compat)
       - name: Build CLI with all backends
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release'


### PR DESCRIPTION
## Summary

Closes the two automation gaps found while answering "are arvak-lite and the qiskit integration automatically up to date?":

1. **Python Bindings PR job now runs the test suite** (previously: build + doc snippets only). Runs the extras-free selection — core bindings, compile, sim, qiskit integration (144 tests in the CI environment; qrisp/cirq/pennylane tests skip cleanly without their extras; nathan is excluded as it needs heavy optional deps).

2. **Nightly gains a downstream-compat step for arvak-lite**: installs `arvak-lite[qiskit]` from PyPI, force-installs the wheel built from the current commit over it, and smokes the target-compilation path (`transpile(qc, coupling_map=…, basis_gates=…)`) plus the qiskit transpiler plugin. Context: the 2.0 `CouplingMap` constructor change silently broke arvak-lite 0.1.1 in the wild for every fresh install — no CI anywhere covered the combination. (The arvak-lite fix itself is `hiq-lab/arvak-lite@3b561f4`, released as 0.1.2 once arvak 2.1.3 is on PyPI.)

## Verification

- Test selection validated in a CI-equivalent venv (wheel + pytest + qiskit only, no qrisp): 144 passed, 80 skipped, 0 errors
- The compat smoke is exactly the reproduction of the arvak-lite breakage, now guarded
- Both workflow files YAML-validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)