### PR TITLE
ci: restore full-target caches for Test Suite and Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,20 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      # Full-target cache incl. workspace artifacts: incremental rebuilds
+      # keep this job at ~3min. Swatinem/rust-cache deliberately drops
+      # workspace artifacts, which tripled the runtime here.
+      - name: Cache cargo (full target)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-test-
 
       - name: Run tests
         run: cargo test --workspace --exclude arvak-python
@@ -96,8 +108,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      # Full-target cache incl. workspace artifacts (see Test Suite note).
+      - name: Cache cargo (full target)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-clippy-
 
       - name: Run clippy
         run: >


### PR DESCRIPTION
## Summary

Follow-up to #52 with measured warm-cache numbers. The rust-cache switch was a win for dependency-dominated jobs but a regression for the two jobs that live off workspace-artifact incrementality — `Swatinem/rust-cache` deliberately drops workspace artifacts:

| Job | pre-#52 warm | post-#52 warm | this PR (expected) |
|---|---|---|---|
| Build | 10.2–10.5 (ubuntu+release) | **1.2** (macOS debug) | 1.2 |
| Documentation | ~4.0 | **0.7** | 0.7 |
| Test Suite | 3.1–3.9 | **9.4** ❌ | ~3 |
| Clippy | 1.1 | **4.1** ❌ | ~1–2 |
| Python Bindings | ~5.1 | 5.5 | ~5 |

Test Suite and Clippy go back to manual full-`target/` caches, improved over the pre-#52 design: the primary key now includes the commit SHA, so every run **saves** updated artifacts and the next run restores the freshest previous cache via `restore-keys`. The old lockfile-only key saved once per lockfile change and served increasingly stale artifacts afterwards.

Expected steady-state PR wall-clock: **~5 min** (bounded by Python Bindings), vs ~10.5 min before #52.

Measurement plan after merge: run 1 seeds the new cache keys, run 2 is the steady-state number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)